### PR TITLE
print additional columns for policy

### DIFF
--- a/deploy/crds/policy.open-cluster-management.io_policies_crd.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policies_crd.yaml
@@ -13,7 +13,17 @@ spec:
     singular: policy
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.remediationAction
+      name: Remediation action
+      type: string
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Policy is the Schema for the policies API

--- a/pkg/apis/policy/v1/policy_types.go
+++ b/pkg/apis/policy/v1/policy_types.go
@@ -95,6 +95,9 @@ type PolicyStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=policies,scope=Namespaced
 // +kubebuilder:resource:path=policies,shortName=plc
+// +kubebuilder:printcolumn:name="Remediation action",type="string",JSONPath=".spec.remediationAction"
+// +kubebuilder:printcolumn:name="Compliance state",type="string",JSONPath=".status.compliant"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Policy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3318

```
ycao@MacBook-Pro governance-policy-propagator % kubectl get policy -A     
I0421 10:49:37.630466   92294 request.go:645] Throttling request took 1.147729156s, request: GET:https://api.policy-grc-cp-autoclaims-cjcz2.dev08.red-chesterfield.com:6443/apis/webhook.certmanager.k8s.io/v1beta1?timeout=32s
NAMESPACE       NAME                                          REMEDIATION ACTION   COMPLIANCE STATE   AGE
default         policy-install-acs-central                    enforce              Compliant          149m
default         policy-install-acs-cluster-services           enforce              Compliant          19m
default         test-pod-policy-dhaiduce                      enforce              Compliant          40m
gparvin         default.policy-install-acs-cluster-services   enforce              Compliant          19m
gparvin         default.test-pod-policy-dhaiduce              enforce              Compliant          5m17s
local-cluster   default.policy-install-acs-central            enforce              Compliant          149m
local-cluster   default.test-pod-policy-dhaiduce              enforce              Compliant          5m17s
```