### PR TITLE
set the mc policy owner reference to the parent policy

### DIFF
--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -231,6 +231,8 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 			labels[common.ClusterNamespaceLabel] = decision.ClusterNamespace
 			labels[common.RootPolicyLabel] = common.FullNameForPolicy(instance)
 			replicatedPlc.SetLabels(labels)
+			// Make sure the parent policy is the owner
+			replicatedPlc.SetOwnerReferences(instance.OwnerReferences)
 			reqLogger.Info("Creating replicated policy...", "Namespace", decision.ClusterNamespace,
 				"Name", common.FullNameForPolicy(instance))
 			err = r.client.Create(context.TODO(), replicatedPlc)

--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -232,10 +232,9 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 			labels[common.RootPolicyLabel] = common.FullNameForPolicy(instance)
 			replicatedPlc.SetLabels(labels)
 
-			// Make sure the parent policy is the owner
-			replicatedPlc.SetOwnerReferences([]metav1.OwnerReference{
-				*metav1.NewControllerRef(instance, instance.GroupVersionKind()),
-			})
+			// Make sure the Owner Reference is cleared
+			replicatedPlc.SetOwnerReferences(nil)
+
 			reqLogger.Info("Creating replicated policy...", "Namespace", decision.ClusterNamespace,
 				"Name", common.FullNameForPolicy(instance))
 			err = r.client.Create(context.TODO(), replicatedPlc)

--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -232,7 +232,14 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 			labels[common.RootPolicyLabel] = common.FullNameForPolicy(instance)
 			replicatedPlc.SetLabels(labels)
 			// Make sure the parent policy is the owner
-			replicatedPlc.SetOwnerReferences(instance.OwnerReferences)
+			var owners []metav1.OwnerReference = make([]metav1.OwnerReference, 1)
+			owners[0] = metav1.OwnerReference{
+				APIVersion: "policy.open-cluster-management.io/v1",
+				Kind:       "policy",
+				Name:       instance.Name,
+				UID:        instance.UID,
+			}
+			replicatedPlc.SetOwnerReferences(owners)
 			reqLogger.Info("Creating replicated policy...", "Namespace", decision.ClusterNamespace,
 				"Name", common.FullNameForPolicy(instance))
 			err = r.client.Create(context.TODO(), replicatedPlc)

--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -231,11 +231,12 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 			labels[common.ClusterNamespaceLabel] = decision.ClusterNamespace
 			labels[common.RootPolicyLabel] = common.FullNameForPolicy(instance)
 			replicatedPlc.SetLabels(labels)
+			replicatedPlc.SetManagedFields(nil)
 			// Make sure the parent policy is the owner
 			var owners []metav1.OwnerReference = make([]metav1.OwnerReference, 1)
 			owners[0] = metav1.OwnerReference{
 				APIVersion: "policy.open-cluster-management.io/v1",
-				Kind:       "policy",
+				Kind:       "Policy",
 				Name:       instance.Name,
 				UID:        instance.UID,
 			}

--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -231,16 +231,11 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 			labels[common.ClusterNamespaceLabel] = decision.ClusterNamespace
 			labels[common.RootPolicyLabel] = common.FullNameForPolicy(instance)
 			replicatedPlc.SetLabels(labels)
-			replicatedPlc.SetManagedFields(nil)
+
 			// Make sure the parent policy is the owner
-			var owners []metav1.OwnerReference = make([]metav1.OwnerReference, 1)
-			owners[0] = metav1.OwnerReference{
-				APIVersion: "policy.open-cluster-management.io/v1",
-				Kind:       "Policy",
-				Name:       instance.Name,
-				UID:        instance.UID,
-			}
-			replicatedPlc.SetOwnerReferences(owners)
+			replicatedPlc.SetOwnerReferences([]metav1.OwnerReference{
+				*metav1.NewControllerRef(instance, instance.GroupVersionKind()),
+			})
 			reqLogger.Info("Creating replicated policy...", "Namespace", decision.ClusterNamespace,
 				"Name", common.FullNameForPolicy(instance))
 			err = r.client.Create(context.TODO(), replicatedPlc)


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>

Make sure the owner reference for the managed cluster hub policies is the parent policy -- not the owner reference in the parent policy which can be anything.

**Update** Using the parent policy just would not work for some reason -- instead clearing the OwnerReference has fixed the problem that I'm seeing.  Note that the problem can be recreated by:

1. Clone repo `git@github.com:rcarrillocruz/cluster-group-lcm.git`
2. Run `make install run`
3. Create the `Group` resource from the group.yaml but make sure you update the managed cluster reference from `spoke1` and `spoke2` to something you have.

This causes a policy to be created with the operator or group as the owner and we currently do a DeepCopy which keeps that owner reference.  This causes lots of errors like this in the events:

```
36s         Warning   OwnerRefInvalidNamespace                        policy/default.group1-batch-1-policy-deployment-policy   ownerRef [policy.open-cluster-management.io/v1/Policy, namespace: local-cluster, name: group1-batch-1-policy-deployment-policy, uid: 184c6961-667c-46f2-b761-4886adf31fe3] does not exist in namespace "local-cluster"
```
And we get into a tight loop with those events and the policy seems to be continually reconciled.

With this pr it is back to normal.