### PR TITLE
bug fix - do not copy finalizers from user namespace to MC namespaces

### DIFF
--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -223,6 +223,7 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 			replicatedPlc.SetName(common.FullNameForPolicy(instance))
 			replicatedPlc.SetNamespace(decision.ClusterNamespace)
 			replicatedPlc.SetResourceVersion("")
+			replicatedPlc.SetFinalizers(nil)
 			labels := replicatedPlc.GetLabels()
 			if labels == nil {
 				labels = map[string]string{}


### PR DESCRIPTION
fix a bug of copying finalizers from user namespace to clusters namespaces.
finalizer has to be removed to avoid having the policy stuck forever on the MCs.

Signed-off-by: Nir Rozenbaum <nirro@il.ibm.com>