### PR TITLE
Add tests for the policy info metrics

### DIFF
--- a/test/e2e/case6_metrics_test.go
+++ b/test/e2e/case6_metrics_test.go
@@ -49,15 +49,15 @@ var _ = Describe("Test metrics appear locally", func() {
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		By("Checking metric endpoint for root policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 	})
 	It("should report 1 for noncompliant root policy and replicated policies", func() {
@@ -79,15 +79,15 @@ var _ = Describe("Test metrics appear locally", func() {
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		By("Checking metric endpoint for root policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 	})
 	It("should not report metrics for policies after they are deleted", func() {
@@ -99,15 +99,15 @@ var _ = Describe("Test metrics appear locally", func() {
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		By("Checking metric endpoint for root policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 	})
 })

--- a/test/e2e/case6_metrics_test.go
+++ b/test/e2e/case6_metrics_test.go
@@ -1,0 +1,113 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/pkg/apis/policy/v1"
+	"github.com/open-cluster-management/governance-policy-propagator/pkg/controller/common"
+	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const case6PolicyName string = "case6-test-policy"
+const case6PolicyYaml string = "../resources/case6_metrics/case6-test-policy.yaml"
+
+var _ = Describe("Test metrics appear locally", func() {
+	It("should report 0 for compliant root policy and replicated policies", func() {
+		By("Creating " + case6PolicyYaml)
+		utils.Kubectl("apply",
+			"-f", case6PolicyYaml,
+			"-n", testNamespace)
+		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+		By("Patching test-policy-plr with decision of cluster managed1 and managed2")
+		plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case6PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+		plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
+		_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+		Expect(err).To(BeNil())
+		plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed2", true, defaultTimeoutSeconds)
+		Expect(plc).ToNot(BeNil())
+		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+		By("Patching both replicated policy status to compliant")
+		replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		for _, replicatedPlc := range replicatedPlcList.Items {
+			replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
+				ComplianceState: policiesv1.Compliant,
+			}
+			_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+			Expect(err).To(BeNil())
+		}
+		By("Checking the status of root policy")
+		yamlPlc := utils.ParseYaml("../resources/case6_metrics/managed-both-status-compliant.yaml")
+		Eventually(func() interface{} {
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			return rootPlc.Object["status"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
+		By("Checking metric endpoint for root policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
+		By("Checking metric endpoint for managed1 replicated policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
+		By("Checking metric endpoint for managed2 replicated policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
+	})
+	It("should report 1 for noncompliant root policy and replicated policies", func() {
+		By("Patching both replicated policy status to noncompliant")
+		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+		replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		for _, replicatedPlc := range replicatedPlcList.Items {
+			replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
+				ComplianceState: policiesv1.NonCompliant,
+			}
+			_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+			Expect(err).To(BeNil())
+		}
+		By("Checking the status of root policy")
+		yamlPlc := utils.ParseYaml("../resources/case6_metrics/managed-both-status-noncompliant.yaml")
+		Eventually(func() interface{} {
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			return rootPlc.Object["status"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
+		By("Checking metric endpoint for root policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
+		By("Checking metric endpoint for managed1 replicated policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
+		By("Checking metric endpoint for managed2 replicated policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
+	})
+	It("should not report metrics for policies after they are deleted", func() {
+		By("Deleting the policy")
+		utils.Kubectl("delete",
+			"-f", case6PolicyYaml,
+			"-n", testNamespace)
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
+		By("Checking metric endpoint for root policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
+		By("Checking metric endpoint for managed1 replicated policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
+		By("Checking metric endpoint for managed2 replicated policy status")
+		Eventually(func() interface{} {
+			return utils.GetMetric("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
+	})
+})

--- a/test/resources/case6_metrics/case6-test-policy.yaml
+++ b/test/resources/case6_metrics/case6-test-policy.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case6-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case6-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case6-test-policy-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case6-test-policy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case6-test-policy
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case6-test-policy-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/case6_metrics/managed-both-status-compliant.yaml
+++ b/test/resources/case6_metrics/managed-both-status-compliant.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case6-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case6-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+status:
+  compliant: Compliant 
+  placement:
+  - placementBinding: case6-test-policy-pb
+    placementRule: case6-test-policy-plr
+  status:
+  - clustername: managed1
+    clusternamespace: managed1
+    compliant: Compliant
+  - clustername: managed2
+    clusternamespace: managed2
+    compliant: Compliant

--- a/test/resources/case6_metrics/managed-both-status-noncompliant.yaml
+++ b/test/resources/case6_metrics/managed-both-status-noncompliant.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case6-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case6-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+status:
+  compliant: NonCompliant
+  placement:
+  - placementBinding: case6-test-policy-pb
+    placementRule: case6-test-policy-plr
+  status:
+  - clustername: managed1
+    clusternamespace: managed1
+    compliant: NonCompliant
+  - clustername: managed2
+    clusternamespace: managed2
+    compliant: NonCompliant

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -203,4 +204,38 @@ func KubectlWithOutput(args ...string) (string, error) {
 	output, err := exec.Command("kubectl", args...).CombinedOutput()
 	fmt.Println(string(output))
 	return string(output), err
+}
+
+// GetMetric execs into the propagator pod and curls the metrics endpoint, filters
+// the response with the given patterns, and returns the value(s) for the matching
+// metric(s).
+func GetMetric(metricPatterns ...string) []string {
+	propPodInfo, err := KubectlWithOutput("get", "pod", "-n=open-cluster-management",
+		"-l=name=governance-policy-propagator", "--no-headers")
+	if err != nil {
+		return []string{err.Error()}
+	}
+	propPodName := strings.Split(propPodInfo, " ")[0]
+
+	metricFilter := " | grep " + strings.Join(metricPatterns, " | grep ")
+	cmd := exec.Command("kubectl", "exec", "-n=open-cluster-management", propPodName,
+		"--", "bash", "-c", `curl localhost:8383/metrics`+metricFilter)
+	matchingMetricsRaw, err := cmd.Output()
+	if err != nil {
+		if err.Error() == "exit status 1" {
+			return []string{} // exit 1 indicates that grep couldn't find a match.
+		}
+		return []string{err.Error()}
+	}
+
+	matchingMetrics := strings.Split(strings.TrimSpace(string(matchingMetricsRaw)), "\n")
+	values := make([]string, len(matchingMetrics))
+	for i, metric := range matchingMetrics {
+		fields := strings.Fields(metric)
+		if len(fields) > 0 {
+			values[i] = fields[len(fields)-1]
+		}
+	}
+
+	return values
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -206,10 +206,10 @@ func KubectlWithOutput(args ...string) (string, error) {
 	return string(output), err
 }
 
-// GetMetric execs into the propagator pod and curls the metrics endpoint, filters
+// GetMetrics execs into the propagator pod and curls the metrics endpoint, filters
 // the response with the given patterns, and returns the value(s) for the matching
 // metric(s).
-func GetMetric(metricPatterns ...string) []string {
+func GetMetrics(metricPatterns ...string) []string {
 	propPodInfo, err := KubectlWithOutput("get", "pod", "-n=open-cluster-management",
 		"-l=name=governance-policy-propagator", "--no-headers")
 	if err != nil {


### PR DESCRIPTION
Because the endpoint isn't directly exposed, it would take some extra
work to get it to a "regular" endpoint that the tests could connect to.
So, instead, this exec's into the pod, where it *can* curl the metrics
endpoint directly. The new util function could be useful for testing
other metrics in the future.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/14992

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>