### PR TITLE
Add env vars for controller QPS and Burst tuning

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/open-cluster-management/governance-policy-propagator/pkg/apis"
@@ -65,8 +66,25 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Some default tuned values here, but can be overriden via env vars
 	cfg.QPS = 200.0
 	cfg.Burst = 400
+	qpsOverride, found := os.LookupEnv("CONTROLLER_CONFIG_QPS")
+	if found {
+		qpsVal, err := strconv.ParseFloat(qpsOverride, 32)
+		if err == nil {
+			cfg.QPS = float32(qpsVal)
+			log.Info(fmt.Sprintf("Using QPS override: %v", cfg.QPS))
+		}
+	}
+	burstOverride, found := os.LookupEnv("CONTROLLER_CONFIG_BURST")
+	if found {
+		burstVal, err := strconv.Atoi(burstOverride)
+		if err == nil {
+			cfg.Burst = burstVal
+			log.Info(fmt.Sprintf("Using Burst override: %v", cfg.Burst))
+		}
+	}
 
 	ctx := context.TODO()
 	// Become the leader before proceeding


### PR DESCRIPTION
Previous testing had shown that the new values for QPS and Burst (200.0
and 400, respectively) work better for us than the controller-runtime
defaults. However, further tuning may be needed in the future. These
environment variables, as well as the (now) exposed
ocm_handle_root_policy_duration_seconds metric should help in that
process.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/14583

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>