### PR TITLE
Fix name collision (case6) on tests

### DIFF
--- a/test/e2e/case8_metrics_test.go
+++ b/test/e2e/case8_metrics_test.go
@@ -13,25 +13,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case6PolicyName string = "case6-test-policy"
-const case6PolicyYaml string = "../resources/case6_metrics/case6-test-policy.yaml"
+const case8PolicyName string = "case8-test-policy"
+const case8PolicyYaml string = "../resources/case8_metrics/case8-test-policy.yaml"
 
 var _ = Describe("Test metrics appear locally", func() {
 	It("should report 0 for compliant root policy and replicated policies", func() {
-		By("Creating " + case6PolicyYaml)
+		By("Creating " + case8PolicyYaml)
 		utils.Kubectl("apply",
-			"-f", case6PolicyYaml,
+			"-f", case8PolicyYaml,
 			"-n", testNamespace)
-		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds)
 		Expect(plc).NotTo(BeNil())
 		By("Patching test-policy-plr with decision of cluster managed1 and managed2")
-		plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case6PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+		plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case8PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
 		plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
 		_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 		Expect(err).To(BeNil())
-		plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed2", true, defaultTimeoutSeconds)
+		plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case8PolicyName, "managed2", true, defaultTimeoutSeconds)
 		Expect(plc).ToNot(BeNil())
-		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case8PolicyName}
 		By("Patching both replicated policy status to compliant")
 		replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		for _, replicatedPlc := range replicatedPlcList.Items {
@@ -42,27 +42,27 @@ var _ = Describe("Test metrics appear locally", func() {
 			Expect(err).To(BeNil())
 		}
 		By("Checking the status of root policy")
-		yamlPlc := utils.ParseYaml("../resources/case6_metrics/managed-both-status-compliant.yaml")
+		yamlPlc := utils.ParseYaml("../resources/case8_metrics/managed-both-status-compliant.yaml")
 		Eventually(func() interface{} {
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds)
 			return rootPlc.Object["status"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		By("Checking metric endpoint for root policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `type=\"root\"`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 	})
 	It("should report 1 for noncompliant root policy and replicated policies", func() {
 		By("Patching both replicated policy status to noncompliant")
-		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case8PolicyName}
 		replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		for _, replicatedPlc := range replicatedPlcList.Items {
 			replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
@@ -72,42 +72,42 @@ var _ = Describe("Test metrics appear locally", func() {
 			Expect(err).To(BeNil())
 		}
 		By("Checking the status of root policy")
-		yamlPlc := utils.ParseYaml("../resources/case6_metrics/managed-both-status-noncompliant.yaml")
+		yamlPlc := utils.ParseYaml("../resources/case8_metrics/managed-both-status-noncompliant.yaml")
 		Eventually(func() interface{} {
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds)
 			return rootPlc.Object["status"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		By("Checking metric endpoint for root policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `type=\"root\"`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 	})
 	It("should not report metrics for policies after they are deleted", func() {
 		By("Deleting the policy")
 		utils.Kubectl("delete",
-			"-f", case6PolicyYaml,
+			"-f", case8PolicyYaml,
 			"-n", testNamespace)
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		By("Checking metric endpoint for root policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `type=\"root\"`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `type=\"root\"`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case6-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 	})
 })

--- a/test/resources/case8_metrics/case8-test-policy.yaml
+++ b/test/resources/case8_metrics/case8-test-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: case6-test-policy
+  name: case8-test-policy
 spec:
   remediationAction: inform
   disabled: false
@@ -10,7 +10,7 @@ spec:
         apiVersion: policies.ibm.com/v1alpha1
         kind: TrustedContainerPolicy
         metadata:
-          name: case6-test-policy-trustedcontainerpolicy
+          name: case8-test-policy-trustedcontainerpolicy
         spec:
           severity: low
           namespaceSelector:
@@ -22,20 +22,20 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: case6-test-policy-pb
+  name: case8-test-policy-pb
 placementRef:
   apiGroup: apps.open-cluster-management.io
   kind: PlacementRule
-  name: case6-test-policy-plr
+  name: case8-test-policy-plr
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
-  name: case6-test-policy
+  name: case8-test-policy
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: case6-test-policy-plr
+  name: case8-test-policy-plr
 spec:
   clusterConditions:
   - status: "True"

--- a/test/resources/case8_metrics/managed-both-status-compliant.yaml
+++ b/test/resources/case8_metrics/managed-both-status-compliant.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: case6-test-policy
+  name: case8-test-policy
 spec:
   remediationAction: inform
   disabled: false
@@ -10,7 +10,7 @@ spec:
         apiVersion: policies.ibm.com/v1alpha1
         kind: TrustedContainerPolicy
         metadata:
-          name: case6-test-policy-trustedcontainerpolicy
+          name: case8-test-policy-trustedcontainerpolicy
         spec:
           severity: low
           namespaceSelector:
@@ -19,14 +19,14 @@ spec:
           remediationAction: inform
           imageRegistry: quay.io
 status:
-  compliant: NonCompliant
+  compliant: Compliant 
   placement:
-  - placementBinding: case6-test-policy-pb
-    placementRule: case6-test-policy-plr
+  - placementBinding: case8-test-policy-pb
+    placementRule: case8-test-policy-plr
   status:
   - clustername: managed1
     clusternamespace: managed1
-    compliant: NonCompliant
+    compliant: Compliant
   - clustername: managed2
     clusternamespace: managed2
-    compliant: NonCompliant
+    compliant: Compliant

--- a/test/resources/case8_metrics/managed-both-status-noncompliant.yaml
+++ b/test/resources/case8_metrics/managed-both-status-noncompliant.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: case6-test-policy
+  name: case8-test-policy
 spec:
   remediationAction: inform
   disabled: false
@@ -10,7 +10,7 @@ spec:
         apiVersion: policies.ibm.com/v1alpha1
         kind: TrustedContainerPolicy
         metadata:
-          name: case6-test-policy-trustedcontainerpolicy
+          name: case8-test-policy-trustedcontainerpolicy
         spec:
           severity: low
           namespaceSelector:
@@ -19,14 +19,14 @@ spec:
           remediationAction: inform
           imageRegistry: quay.io
 status:
-  compliant: Compliant 
+  compliant: NonCompliant
   placement:
-  - placementBinding: case6-test-policy-pb
-    placementRule: case6-test-policy-plr
+  - placementBinding: case8-test-policy-pb
+    placementRule: case8-test-policy-plr
   status:
   - clustername: managed1
     clusternamespace: managed1
-    compliant: Compliant
+    compliant: NonCompliant
   - clustername: managed2
     clusternamespace: managed2
-    compliant: Compliant
+    compliant: NonCompliant


### PR DESCRIPTION
The metrics tests will now be case 8.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

https://github.com/open-cluster-management/governance-policy-propagator/pull/83 and https://github.com/open-cluster-management/governance-policy-propagator/pull/81 collided, both defined case6 for their tests.