### PR TITLE
Add E2E tests for hub side template indentation

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -109,6 +109,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
 
 ---
 kind: RoleBinding

--- a/test/resources/case9_templates/case9-test-policy.yaml
+++ b/test/resources/case9_templates/case9-test-policy.yaml
@@ -30,6 +30,10 @@ spec:
                   Clusterid: '{{ fromClusterClaim id.openshift.io }}'
                   Vlanid: |
                     '{{hub printf "%s-vlanid" .ManagedClusterName | fromConfigMap "policy-propagator-test" "case9-config"  | toInt hub}}'
+                  indent-test: |
+                    {{hub fromSecret "policy-propagator-test" "case9-secret" "saying" | base64dec | indent 4 hub}}
+                  autoindent-test: |
+                    {{hub fromSecret "policy-propagator-test" "case9-secret" "saying" | base64dec | autoindent hub}}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -63,3 +67,10 @@ metadata:
 data:
   managed1-vlanid: "123"
   managed2-vlanid: "456"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: case9-secret
+data:
+  saying: RG8uCk9yIGRvIG5vdC4KVGhlcmUgaXMgbm8gdHJ5Lgo=

--- a/test/resources/case9_templates/case9-test-replpolicy-managed1.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed1.yaml
@@ -28,3 +28,11 @@ spec:
                   Clustername: managed1
                   Clusterid: '{{ fromClusterClaim id.openshift.io }}'
                   Vlanid: 123
+                  indent-test: |
+                    Do.
+                    Or do not.
+                    There is no try.
+                  autoindent-test: |
+                    Do.
+                    Or do not.
+                    There is no try.

--- a/test/resources/case9_templates/case9-test-replpolicy-managed2.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed2.yaml
@@ -28,3 +28,11 @@ spec:
                   Clustername: managed2
                   Clusterid: '{{ fromClusterClaim id.openshift.io }}'
                   Vlanid: 456
+                  indent-test: |
+                    Do.
+                    Or do not.
+                    There is no try.
+                  autoindent-test: |
+                    Do.
+                    Or do not.
+                    There is no try.


### PR DESCRIPTION
This is testing functionality added in:
https://github.com/open-cluster-management/governance-policy-propagator/commit/d0d1645714ebc3e5a198b431eed5a8f8ba3ea12d

The first commit grants the service account read access to everything to match the GRC helm chart configuration. This is required for testing hub side templates which lookup secrets.