### PR TITLE
Fix all linting errors

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -50,8 +50,10 @@ jobs:
 
     - name: Verify format
       run: |
+        make fmt-dependencies
         make fmt
         git diff --exit-code
+        make lint
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ GIT_HOST ?= github.com/open-cluster-management
 
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
+export PATH=$(shell echo $$PATH):$(PWD)/bin
 
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go
@@ -67,7 +68,7 @@ else
     $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
 endif
 
-.PHONY: fmt lint test coverage build build-images
+.PHONY: fmt lint test coverage build build-images fmt-dependencies lint-dependencies
 
 USE_VENDORIZED_BUILD_HARNESS ?=
 
@@ -97,11 +98,17 @@ work: $(GOBIN)
 # format section
 ############################################################
 
+fmt-dependencies:
+	$(call go-get-tool,$(PWD)/bin/gci,github.com/daixiang0/gci@v0.2.9)
+	$(call go-get-tool,$(PWD)/bin/gofumpt,mvdan.cc/gofumpt@v0.2.0)
+
 # All available format: format-go format-protos format-python
 # Default value will run all formats, override these make target with your requirements:
 #    eg: fmt: format-go format-protos
-fmt: # format-go format-protos format-python
-	go fmt ./...
+fmt: fmt-dependencies
+	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gofmt -s -w
+	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gci -w -local "$(shell cat go.mod | head -1 | cut -d " " -f 2)"
+	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gofumpt -l -w
 
 ############################################################
 # check section
@@ -109,10 +116,13 @@ fmt: # format-go format-protos format-python
 
 check: lint
 
+lint-dependencies:
+	$(call go-get-tool,$(PWD)/bin/golangci-lint,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1)
+
 # All available linters: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos
 # Default value will run all linters, override these make target with your requirements:
 #    eg: lint: lint-go lint-yaml
-lint: lint-all
+lint: lint-dependencies lint-all
 
 ############################################################
 # test section

--- a/api/v1/placementbinding_types.go
+++ b/api/v1/placementbinding_types.go
@@ -21,11 +21,7 @@ type Subject struct {
 }
 
 // PlacementBindingStatus defines the observed state of PlacementBinding
-type PlacementBindingStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-}
+type PlacementBindingStatus struct{}
 
 //+kubebuilder:object:root=true
 

--- a/api/v1/policy_types.go
+++ b/api/v1/policy_types.go
@@ -21,7 +21,7 @@ const (
 	Inform RemediationAction = "Inform"
 )
 
-//PolicyTemplate template for custom security policy
+// PolicyTemplate template for custom security policy
 type PolicyTemplate struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	ObjectDefinition runtime.RawExtension `json:"objectDefinition"`

--- a/api/v1beta1/policyautomation_types.go
+++ b/api/v1beta1/policyautomation_types.go
@@ -43,11 +43,7 @@ type AutomationDef struct {
 }
 
 // PolicyAutomationStatus defines the observed state of PolicyAutomation
-type PolicyAutomationStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-}
+type PolicyAutomationStatus struct{}
 
 //+kubebuilder:object:root=true
 

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -30,7 +30,7 @@ get-cluster-credentials: activate-serviceaccount
 config-docker: get-cluster-credentials
 	@build/common/scripts/config_docker.sh
 
-FINDFILES=find . \( -path ./.git -o -path ./.github \) -prune -o -type f
+FINDFILES=find . \( -path ./.git -o -path ./.github -o -path ./.go \) -prune -o -type f
 XARGS = xargs -0 ${XARGS_FLAGS}
 CLEANXARGS = xargs ${XARGS_FLAGS}
 

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -27,18 +27,32 @@ run:
 linters:
   enable-all: true
   disable:
+    - bodyclose
+    - cyclop
     - depguard
     - dupl
+    - funlen
+    - exhaustivestruct
     - gochecknoglobals
     - gochecknoinits
+    - gocognit
     - goconst
     - gocyclo
+    - godot
+    - goerr113
+    - gomnd
+    - gomoddirectives
     - gosec
+    - ifshort
+    - interfacer
+    - maligned
     - nakedret
+    - nestif
+    - paralleltest
     - prealloc
     - scopelint
-    - funlen
-    - bodyclose
+    - testpackage
+    - wrapcheck
   fast: false
 
 linters-settings:
@@ -53,6 +67,8 @@ linters-settings:
   govet:
     # report about shadowed variables
     check-shadowing: false
+  gci:
+    local-prefixes: github.com/open-cluster-management/governance-policy-propagator
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0
@@ -72,9 +88,9 @@ linters-settings:
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 160
+    line-length: 120
     # tab width in spaces. Default to 1.
-    tab-width: 1
+    tab-width: 4
   unused:
     # treat code as a program (not a library) and report unused exported identifiers; default is false.
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
@@ -164,13 +180,38 @@ issues:
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - composite literal uses unkeyed fields
+    - return statements should not be cuddled if block has more than two lines
+    - declarations should never be cuddled
+    - don't use leading k in Go names
 
   exclude-rules:
-    # Exclude some linters from running on test files.
-    - path: _test\.go$|^tests/|^samples/
+    # Allow dot imports in the tests.
+    - path: _test\.go$|^test/
       linters:
-        - errcheck
-        - maligned
+        - gci
+        - golint
+        - revive
+        - stylecheck
+      source: \. "github\.com/onsi/(gomega|ginkgo)"
+    # Allow printing in the tests.
+    - path: _test\.go$|^test/
+      linters:
+        - forbidgo
+      source: fmt\.Print
+    # Add exceptions to API level tagliatelle violations. Can't use nolint comments since
+    # that affects the CRD descriptions of the fields.
+    - path: ^api/
+      linters:
+        - tagliatelle
+      source: json:"policy-templates|json:"extra_vars
+    # Don't enforce max line length for kubebuilder markers
+    - linters:
+        - lll
+      source: \/\/ ?\+kubebuilder
+    # Don't enforce max line length on comments that start with a URL
+    - linters:
+        - lll
+      source: \/\/ ?https?:\/\/
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all

--- a/controllers/automation/PolicyAutomationPredicate.go
+++ b/controllers/automation/PolicyAutomationPredicate.go
@@ -3,27 +3,35 @@
 package automation
 
 import (
-	policyv1beta1 "github.com/open-cluster-management/governance-policy-propagator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	policyv1beta1 "github.com/open-cluster-management/governance-policy-propagator/api/v1beta1"
 )
 
 // we only want to watch for pb contains policy as subjects
 var policyAuomtationPredicateFuncs = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
+		// nolint: forcetypeassert
 		policyAutomationNew := e.ObjectNew.(*policyv1beta1.PolicyAutomation)
+		// nolint: forcetypeassert
 		policyAutomationOld := e.ObjectOld.(*policyv1beta1.PolicyAutomation)
+
 		if policyAutomationNew.Spec.PolicyRef == "" {
 			return false
 		}
+
 		if policyAutomationNew.ObjectMeta.Annotations["policy.open-cluster-management.io/rerun"] == "true" {
 			return true
 		}
+
 		return !equality.Semantic.DeepEqual(policyAutomationNew.Spec, policyAutomationOld.Spec)
 	},
 	CreateFunc: func(e event.CreateEvent) bool {
+		// nolint: forcetypeassert
 		policyAutomationNew := e.Object.(*policyv1beta1.PolicyAutomation)
+
 		return policyAutomationNew.Spec.PolicyRef != ""
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {

--- a/controllers/automation/policyMapper.go
+++ b/controllers/automation/policyMapper.go
@@ -5,32 +5,41 @@ package automation
 import (
 	"context"
 
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
-	policyv1beta1 "github.com/open-cluster-management/governance-policy-propagator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
+	policyv1beta1 "github.com/open-cluster-management/governance-policy-propagator/api/v1beta1"
 )
 
 func policyMapper(c client.Client) handler.MapFunc {
 	return func(obj client.Object) []reconcile.Request {
+		// nolint: forcetypeassert
 		policy := obj.(*policiesv1.Policy)
+
 		var result []reconcile.Request
+
 		policyAutomationList := &policyv1beta1.PolicyAutomationList{}
+
 		err := c.List(context.TODO(), policyAutomationList, &client.ListOptions{Namespace: policy.GetNamespace()})
 		if err != nil {
 			return nil
 		}
+
 		found := false
 		policyAutomation := policyv1beta1.PolicyAutomation{}
+
 		for _, policyAutomationTemp := range policyAutomationList.Items {
 			if policyAutomationTemp.Spec.PolicyRef == policy.GetName() {
 				found = true
 				policyAutomation = policyAutomationTemp
+
 				break
 			}
 		}
+
 		if found {
 			if policyAutomation.Spec.Mode == "scan" {
 				// scan mode, do not queue
@@ -42,6 +51,7 @@ func policyMapper(c client.Client) handler.MapFunc {
 				result = append(result, request)
 			}
 		}
+
 		return result
 	}
 }

--- a/controllers/automation/policyPredicate.go
+++ b/controllers/automation/policyPredicate.go
@@ -3,19 +3,24 @@
 package automation
 
 import (
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 )
 
 // we only want to watch for pb contains policy as subjects
 var policyPredicateFuncs = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
+		// nolint: forcetypeassert
 		plcObjNew := e.ObjectNew.(*policiesv1.Policy)
 		if _, ok := plcObjNew.Labels["policy.open-cluster-management.io/root-policy"]; ok {
 			return false
 		}
+
+		// nolint: forcetypeassert
 		plcObjOld := e.ObjectOld.(*policiesv1.Policy)
+
 		return plcObjNew.Status.ComplianceState != plcObjOld.Status.ComplianceState
 	},
 	CreateFunc: func(e event.CreateEvent) bool {

--- a/controllers/common/ansible.go
+++ b/controllers/common/ansible.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -33,26 +32,36 @@ func CreateAnsibleJob(policyAutomation *policyv1beta1.PolicyAutomation,
 	if policyAutomation.Spec.Automation.ExtraVars != nil {
 		// This is to translate the runtime.RawExtension to a map[string]interface{}
 		mapExtraVars := map[string]interface{}{}
+
 		err := json.Unmarshal(policyAutomation.Spec.Automation.ExtraVars.Raw, &mapExtraVars)
 		if err != nil {
 			return err
 		}
+
 		ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"] = mapExtraVars
 	}
+
 	if targetClusters != nil {
-		ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["target_clusters"] = targetClusters
+		// nolint: forcetypeassert
+		extravars := ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})
+		extravars["target_clusters"] = targetClusters
 	}
 
-	ansibleJobRes := schema.GroupVersionResource{Group: "tower.ansible.com", Version: "v1alpha1",
-		Resource: "ansiblejobs"}
+	ansibleJobRes := schema.GroupVersionResource{
+		Group: "tower.ansible.com", Version: "v1alpha1",
+		Resource: "ansiblejobs",
+	}
+
 	ansibleJob.SetGenerateName(policyAutomation.GetName() + "-" + mode + "-")
 	ansibleJob.SetOwnerReferences([]metav1.OwnerReference{
 		*metav1.NewControllerRef(policyAutomation, policyAutomation.GroupVersionKind()),
 	})
+
 	_, err := dynamicClient.Resource(ansibleJobRes).Namespace(policyAutomation.GetNamespace()).
-		Create(context.TODO(), ansibleJob, v1.CreateOptions{})
+		Create(context.TODO(), ansibleJob, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -5,14 +5,17 @@ package common
 
 import (
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 )
 
-const APIGroup string = "policy.open-cluster-management.io"
-const ClusterNameLabel string = APIGroup + "/cluster-name"
-const ClusterNamespaceLabel string = APIGroup + "/cluster-namespace"
-const RootPolicyLabel string = APIGroup + "/root-policy"
+const (
+	APIGroup              string = "policy.open-cluster-management.io"
+	ClusterNameLabel      string = APIGroup + "/cluster-name"
+	ClusterNamespaceLabel string = APIGroup + "/cluster-namespace"
+	RootPolicyLabel       string = APIGroup + "/root-policy"
+)
 
 // IsInClusterNamespace check if policy is in cluster namespace
 func IsInClusterNamespace(ns string, allClusters []clusterv1.ManagedCluster) bool {
@@ -21,6 +24,7 @@ func IsInClusterNamespace(ns string, allClusters []clusterv1.ManagedCluster) boo
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -40,29 +44,35 @@ func FullNameForPolicy(plc *policiesv1.Policy) string {
 func CompareSpecAndAnnotation(plc1 *policiesv1.Policy, plc2 *policiesv1.Policy) bool {
 	annotationMatch := equality.Semantic.DeepEqual(plc1.GetAnnotations(), plc2.GetAnnotations())
 	specMatch := equality.Semantic.DeepEqual(plc1.Spec, plc2.Spec)
+
 	return annotationMatch && specMatch
 }
 
 // IsPbForPoicy compares group and kind with policy group and kind for given pb
 func IsPbForPoicy(pb *policiesv1.PlacementBinding) bool {
-	subjects := pb.Subjects
 	found := false
+
+	subjects := pb.Subjects
 	for _, subject := range subjects {
 		if subject.Kind == policiesv1.Kind && subject.APIGroup == policiesv1.SchemeGroupVersion.Group {
 			found = true
+
 			break
 		}
 	}
+
 	return found
 }
 
 // FindNonCompliantClustersForPolicy returns cluster in noncompliant status with given policy
 func FindNonCompliantClustersForPolicy(plc *policiesv1.Policy) []string {
 	clusterList := []string{}
+
 	for _, clusterStatus := range plc.Status.Status {
 		if clusterStatus.ComplianceState == policiesv1.NonCompliant {
 			clusterList = append(clusterList, clusterStatus.ClusterName)
 		}
 	}
+
 	return clusterList
 }

--- a/controllers/common/handler.go
+++ b/controllers/common/handler.go
@@ -27,7 +27,6 @@ func (e *EnqueueRequestsFromMapFunc) Create(evt event.CreateEvent, q workqueue.R
 
 // Update implements EventHandler
 func (e *EnqueueRequestsFromMapFunc) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	// e.mapAndEnqueue(q, evt.ObjectOld)
 	e.mapAndEnqueue(q, evt.ObjectNew)
 }
 

--- a/controllers/policymetrics/metrics.go
+++ b/controllers/policymetrics/metrics.go
@@ -8,19 +8,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var (
-	policyStatusGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "policy_governance_info",
-			Help: "The compliance status of the named policy. 0 == Compliant. 1 == NonCompliant",
-		},
-		[]string{
-			"type",              // "root" or "propagated"
-			"policy",            // The name of the root policy
-			"policy_namespace",  // The namespace where the root policy is defined
-			"cluster_namespace", // The namespace where the policy was propagated
-		},
-	)
+var policyStatusGauge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "policy_governance_info",
+		Help: "The compliance status of the named policy. 0 == Compliant. 1 == NonCompliant",
+	},
+	[]string{
+		"type",              // "root" or "propagated"
+		"policy",            // The name of the root policy
+		"policy_namespace",  // The namespace where the root policy is defined
+		"cluster_namespace", // The namespace where the policy was propagated
+	},
 )
 
 func init() {

--- a/controllers/policymetrics/policymetrics_controller.go
+++ b/controllers/policymetrics/policymetrics_controller.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
-	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
+	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 )
 
 const ControllerName string = "policy-metrics"
@@ -54,13 +54,16 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	// Need to know if the policy is a root policy to create the correct prometheus labels
 	// Can't try to use a label on the policy, because the policy might have been deleted.
 	clusterList := &clusterv1.ManagedClusterList{}
+
 	err := r.List(ctx, clusterList, &client.ListOptions{})
 	if err != nil {
 		reqLogger.Error(err, "Failed to list clusters, going to retry...")
+
 		return reconcile.Result{}, err
 	}
 
 	var promLabels map[string]string
+
 	if common.IsInClusterNamespace(request.Namespace, clusterList.Items) {
 		// propagated policies should look like <namespace>.<name>
 		// also note: k8s namespace names follow RFC 1123 (so no "." in it)
@@ -68,8 +71,10 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if len(splitName) < 2 {
 			// Don't do any metrics if the policy is invalid.
 			reqLogger.Info("Invalid policy in cluster namespace: missing root policy ns prefix")
+
 			return reconcile.Result{}, nil
 		}
+
 		promLabels = prometheus.Labels{
 			"type":              "propagated",
 			"policy":            splitName[1],
@@ -86,6 +91,7 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	}
 
 	pol := &policiesv1.Policy{}
+
 	err = r.Get(ctx, request.NamespacedName, pol)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -93,27 +99,35 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			statusGaugeDeleted := policyStatusGauge.Delete(promLabels)
 			reqLogger.Info("Policy not found - must have been deleted.",
 				"status-gauge-deleted", statusGaugeDeleted)
+
 			return reconcile.Result{}, nil
 		}
+
 		reqLogger.Error(err, "Failed to get Policy")
+
 		return reconcile.Result{}, err
 	}
 
 	reqLogger.Info("Got active state", "pol.Spec.Disabled", pol.Spec.Disabled)
+
 	if pol.Spec.Disabled {
 		// The policy is no longer active, so delete its metric
 		statusGaugeDeleted := policyStatusGauge.Delete(promLabels)
 		reqLogger.Info("Metric removed for non-active policy",
 			"status-gauge-deleted", statusGaugeDeleted)
+
 		return reconcile.Result{}, nil
 	}
 
 	reqLogger.Info("Got ComplianceState", "pol.Status.ComplianceState", pol.Status.ComplianceState)
+
 	statusMetric, err := policyStatusGauge.GetMetricWith(promLabels)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get status metric from GaugeVec")
+
 		return reconcile.Result{}, err
 	}
+
 	if pol.Status.ComplianceState == policiesv1.Compliant {
 		statusMetric.Set(0)
 	} else if pol.Status.ComplianceState == policiesv1.NonCompliant {

--- a/controllers/propagator/metric.go
+++ b/controllers/propagator/metric.go
@@ -8,12 +8,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var (
-	roothandlerMeasure = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "ocm_handle_root_policy_duration_seconds",
-		Help: "Time the handleRootPolicy function takes to complete.",
-	})
-)
+var roothandlerMeasure = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name: "ocm_handle_root_policy_duration_seconds",
+	Help: "Time the handleRootPolicy function takes to complete.",
+})
 
 func init() {
 	metrics.Registry.MustRegister(roothandlerMeasure)

--- a/controllers/propagator/placementBindingMapper.go
+++ b/controllers/propagator/placementBindingMapper.go
@@ -4,22 +4,26 @@
 package propagator
 
 import (
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 )
 
 func placementBindingMapper(c client.Client) handler.MapFunc {
 	return func(obj client.Object) []reconcile.Request {
+		// nolint: forcetypeassert
 		object := obj.(*policiesv1.PlacementBinding)
 		var result []reconcile.Request
+
 		subjects := object.Subjects
 		for _, subject := range subjects {
 			if subject.APIGroup == policiesv1.SchemeGroupVersion.Group && subject.Kind == policiesv1.Kind {
 				log.Info("Found reconciliation request from placement binding...",
 					"Namespace", object.GetNamespace(), "Name", object.GetName(), "Policy-Name", subject.Name)
+
 				request := reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      subject.Name,
 					Namespace: object.GetNamespace(),
@@ -27,6 +31,7 @@ func placementBindingMapper(c client.Client) handler.MapFunc {
 				result = append(result, request)
 			}
 		}
+
 		return result
 	}
 }

--- a/controllers/propagator/placementBindingPredicate.go
+++ b/controllers/propagator/placementBindingPredicate.go
@@ -4,25 +4,33 @@
 package propagator
 
 import (
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
-	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
+	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 )
 
 // we only want to watch for pb contains policy as subjects
 var pbPredicateFuncs = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
+		// nolint: forcetypeassert
 		pbObjNew := e.ObjectNew.(*policiesv1.PlacementBinding)
+		// nolint: forcetypeassert
 		pbObjOld := e.ObjectOld.(*policiesv1.PlacementBinding)
+
 		return common.IsPbForPoicy(pbObjNew) || common.IsPbForPoicy(pbObjOld)
 	},
 	CreateFunc: func(e event.CreateEvent) bool {
+		// nolint: forcetypeassert
 		pbObj := e.Object.(*policiesv1.PlacementBinding)
+
 		return common.IsPbForPoicy(pbObj)
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
+		// nolint: forcetypeassert
 		pbObj := e.Object.(*policiesv1.PlacementBinding)
+
 		return common.IsPbForPoicy(pbObj)
 	},
 }

--- a/controllers/propagator/policyMapper.go
+++ b/controllers/propagator/policyMapper.go
@@ -6,11 +6,12 @@ package propagator
 import (
 	"strings"
 
-	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 )
 
 // policyMapper looks at object and returns a slice of reconcile.Request to reconcile
@@ -20,23 +21,28 @@ func policyMapper(c client.Client) handler.MapFunc {
 		rootPlcName := object.GetLabels()[common.RootPolicyLabel]
 		var name string
 		var namespace string
+
 		if rootPlcName != "" {
 			// policy.open-cluster-management.io/root-policy exists, should be a replicated policy
 			log.Info("Found reconciliation request from replicated policy...", "Namespace", object.GetNamespace(),
 				"Name", object.GetName())
+
 			name = strings.Split(rootPlcName, ".")[1]
 			namespace = strings.Split(rootPlcName, ".")[0]
 		} else {
 			// policy.open-cluster-management.io/root-policy doesn't exist, should be a root policy
 			log.Info("Found reconciliation request from root policy...", "Namespace", object.GetNamespace(),
 				"Name", object.GetName())
+
 			name = object.GetName()
 			namespace = object.GetNamespace()
 		}
+
 		request := reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      name,
 			Namespace: namespace,
 		}}
+
 		return []reconcile.Request{request}
 	}
 }

--- a/controllers/propagator/propagation_test.go
+++ b/controllers/propagator/propagation_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
-	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	appsv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 )
 
 func TestInitializeAttempts(t *testing.T) {
@@ -34,6 +35,7 @@ func TestInitializeAttempts(t *testing.T) {
 				defer func() {
 					// Reset to the default values
 					attempts = 0
+
 					err := os.Unsetenv(attemptsEnvName)
 					if err != nil {
 						t.Fatalf("failed to unset the environment variable: %v", err)
@@ -44,6 +46,7 @@ func TestInitializeAttempts(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to set the environment variable: %v", err)
 				}
+
 				var k8sInterface kubernetes.Interface
 				Initialize(&rest.Config{}, &k8sInterface)
 
@@ -73,6 +76,7 @@ func TestInitializeRequeueErrorDelay(t *testing.T) {
 				defer func() {
 					// Reset to the default values
 					requeueErrorDelay = 0
+
 					err := os.Unsetenv(requeueErrorDelayEnvName)
 					if err != nil {
 						t.Fatalf("failed to unset the environment variable: %v", err)
@@ -112,6 +116,7 @@ func TestInitializeConcurrencyPerPolicyEnvName(t *testing.T) {
 				defer func() {
 					// Reset to the default values
 					concurrencyPerPolicy = 0
+
 					err := os.Unsetenv(concurrencyPerPolicyEnvName)
 					if err != nil {
 						t.Fatalf("failed to unset the environment variable: %v", err)
@@ -175,9 +180,11 @@ func TestHandleDecisionWrapper(t *testing.T) {
 		// Load up the decisionsChan channel with all the decisions so that handleDecisionWrapper
 		// will call handleDecision with each.
 		decisionsChan := make(chan appsv1.PlacementDecision, len(decisions))
+
 		for _, decision := range decisions {
 			decisionsChan <- decision
 		}
+
 		resultsChan := make(chan decisionResult, len(decisions))
 
 		// Instantiate the mock PolicyReconciler to pass to handleDecisionWrapper.
@@ -211,7 +218,7 @@ func TestHandleDecisionWrapper(t *testing.T) {
 			if test.ExpectedError {
 				if result.Err == nil {
 					t.Fatal("Expected an error but didn't get one")
-				} else if result.Err != test.Error {
+				} else if result.Err != test.Error { // nolint: errorlint
 					t.Fatalf("Expected the error %v but got: %v", test.Error, result.Err)
 				}
 			} else if result.Err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -10,24 +10,24 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	//+kubebuilder:scaffold:imports
 	policyv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	policyv1beta1 "github.com/open-cluster-management/governance-policy-propagator/api/v1beta1"
-	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
+var (
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -65,7 +65,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/main.go
+++ b/main.go
@@ -12,15 +12,17 @@ import (
 	"strconv"
 	"strings"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	clusterv1alpha1 "github.com/open-cluster-management/api/cluster/v1alpha1"
+	appsv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,16 +30,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
-	clusterv1alpha1 "github.com/open-cluster-management/api/cluster/v1alpha1"
+	//+kubebuilder:scaffold:imports
 	policyv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	policyv1beta1 "github.com/open-cluster-management/governance-policy-propagator/api/v1beta1"
 	automationctrl "github.com/open-cluster-management/governance-policy-propagator/controllers/automation"
 	metricsctrl "github.com/open-cluster-management/governance-policy-propagator/controllers/policymetrics"
 	propagatorctrl "github.com/open-cluster-management/governance-policy-propagator/controllers/propagator"
 	"github.com/open-cluster-management/governance-policy-propagator/version"
-	appsv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
-	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -58,23 +57,26 @@ func init() {
 	utilruntime.Must(clusterv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 
+	//+kubebuilder:scaffold:scheme
 	utilruntime.Must(policyv1.AddToScheme(scheme))
 	utilruntime.Must(policyv1beta1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
 	opts := zap.Options{
 		Development: true,
 	}
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -91,9 +93,10 @@ func main() {
 	// Get a config to talk to the apiserver
 	cfg := config.GetConfigOrDie()
 
-	// Some default tuned values here, but can be overriden via env vars
+	// Some default tuned values here, but can be overridden via env vars
 	cfg.QPS = 200.0
 	cfg.Burst = 400
+
 	qpsOverride, found := os.LookupEnv("CONTROLLER_CONFIG_QPS")
 	if found {
 		qpsVal, err := strconv.ParseFloat(qpsOverride, 32)
@@ -102,6 +105,7 @@ func main() {
 			setupLog.Info(fmt.Sprintf("Using QPS override: %v", cfg.QPS))
 		}
 	}
+
 	burstOverride, found := os.LookupEnv("CONTROLLER_CONFIG_BURST")
 	if found {
 		burstVal, err := strconv.Atoi(burstOverride)
@@ -172,6 +176,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
+
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
@@ -179,6 +184,7 @@ func main() {
 
 	// Setup config and client for propagator to talk to the apiserver
 	var generatedClient kubernetes.Interface = kubernetes.NewForConfigOrDie(mgr.GetConfig())
+
 	propagatorctrl.Initialize(cfg, &generatedClient)
 
 	cache := mgr.GetCache()
@@ -189,11 +195,14 @@ func main() {
 		return []string{obj.(*policyv1.PlacementBinding).PlacementRef.Name}
 	}
 
-	if err := cache.IndexField(context.TODO(), &policyv1.PlacementBinding{}, "placementRef.name", indexFunc); err != nil {
+	if err := cache.IndexField(
+		context.TODO(), &policyv1.PlacementBinding{}, "placementRef.name", indexFunc,
+	); err != nil {
 		panic(err)
 	}
 
 	setupLog.Info("starting manager")
+
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
@@ -202,11 +211,9 @@ func main() {
 
 // reportMetrics returns a bool on whether to report GRC metrics from the propagator
 func reportMetrics() bool {
-	metrics, found := os.LookupEnv("DISABLE_REPORT_METRICS")
-	if found && strings.ToLower(metrics) == "true" {
-		return false
-	}
-	return true
+	metrics, _ := os.LookupEnv("DISABLE_REPORT_METRICS")
+
+	return !strings.EqualFold(metrics, "true")
 }
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes
@@ -214,11 +221,12 @@ func getWatchNamespace() (string, error) {
 	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
 	// which specifies the Namespace to watch.
 	// An empty value means the operator is running with cluster scope.
-	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
+	watchNamespaceEnvVar := "WATCH_NAMESPACE"
 
 	ns, found := os.LookupEnv(watchNamespaceEnvVar)
 	if !found {
 		return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
 	}
+
 	return ns, nil
 }

--- a/test/e2e/case1_propagation_test.go
+++ b/test/e2e/case1_propagation_test.go
@@ -8,16 +8,18 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	appsv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case1PolicyName string = "case1-test-policy"
-const case1PolicyYaml string = "../resources/case1_propagation/case1-test-policy.yaml"
+const (
+	case1PolicyName string = "case1-test-policy"
+	case1PolicyYaml string = "../resources/case1_propagation/case1-test-policy.yaml"
+)
 
 var _ = Describe("Test policy propagation", func() {
 	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update pb/plc", func() {
@@ -26,91 +28,169 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case1PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				testNamespace+"."+case1PolicyName,
+				"managed1",
+				true,
+				defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed2", false, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				testNamespace+"."+case1PolicyName,
+				"managed2",
+				false,
+				defaultTimeoutSeconds,
+			)
 			Expect(plc).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a non existing plr")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["placementRef"] = &policiesv1.Subject{
 				APIGroup: "apps.open-cluster-management.io",
 				Kind:     "PlacementRule",
 				Name:     case1PolicyName + "-plr-nonexists",
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plr")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace, true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["placementRef"] = &policiesv1.Subject{
 				APIGroup: "apps.open-cluster-management.io",
 				Kind:     "PlacementRule",
 				Name:     case1PolicyName + "-plr",
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a plc with wrong apigroup")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy1.open-cluster-management.io",
@@ -118,14 +198,24 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case1PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace, true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -133,14 +223,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case1PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a plc with wrong kind")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -148,14 +249,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case1PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -163,14 +275,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case1PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a plc with wrong name")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -178,14 +301,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case1PolicyName + "1",
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case1PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case1PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -193,18 +327,28 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case1PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with no decision")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = &appsv1.PlacementRuleStatus{}
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should clean up", func() {
@@ -222,43 +366,71 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case1PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should update replicated policy in ns managed1", func() {
 			By("Patching test-policy with spec.remediationAction = enforce")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(rootPlc).NotTo(BeNil())
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("inform"))
 			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(
+				context.TODO(), rootPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			Eventually(func() interface{} {
-				replicatedPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds)
+				replicatedPlc := utils.GetWithTimeout(
+					clientHubDynamic,
+					gvrPolicy,
+					testNamespace+"."+case1PolicyName,
+					"managed1",
+					true,
+					defaultTimeoutSeconds,
+				)
+
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(rootPlc.Object["spec"]))
 		})
 		It("should remove replicated policy in ns managed1", func() {
 			By("Patching test-policy with spec.disabled = true")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(rootPlc).NotTo(BeNil())
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["disabled"]).To(Equal(false))
 			rootPlc.Object["spec"].(map[string]interface{})["disabled"] = true
-			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(
+				context.TODO(), rootPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["disabled"]).To(Equal(true))
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should be created in user ns", func() {
@@ -266,18 +438,28 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case1PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case1PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should update test-policy to a different policy template", func() {
@@ -285,11 +467,21 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", "../resources/case1_propagation/case1-test-policy2.yaml",
 				"-n", testNamespace)
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(rootPlc).NotTo(BeNil())
 			yamlPlc := utils.ParseYaml("../resources/case1_propagation/case1-test-policy2.yaml")
 			Eventually(func() interface{} {
-				replicatedPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case1PolicyName, "managed1", true, defaultTimeoutSeconds)
+				replicatedPlc := utils.GetWithTimeout(
+					clientHubDynamic,
+					gvrPolicy,
+					testNamespace+"."+case1PolicyName,
+					"managed1",
+					true,
+					defaultTimeoutSeconds,
+				)
+
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
 		})

--- a/test/e2e/case2_aggregation_test.go
+++ b/test/e2e/case2_aggregation_test.go
@@ -8,14 +8,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case2PolicyName string = "case2-test-policy"
-const case2PolicyYaml string = "../resources/case2_aggregation/case2-test-policy.yaml"
+const (
+	case2PolicyName string = "case2-test-policy"
+	case2PolicyYaml string = "../resources/case2_aggregation/case2-test-policy.yaml"
+)
 
 var _ = Describe("Test policy status aggregation", func() {
 	Describe("Create policy/pb/plc in ns:"+testNamespace, func() {
@@ -24,58 +27,93 @@ var _ = Describe("Test policy status aggregation", func() {
 			utils.Kubectl("apply",
 				"-f", case2PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 
 		It("should contain status.placement with managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 			By("Checking the status.placement of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed1-status.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("should contain status.placement with both managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 			By("Checking the status.placement of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-status.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("should contain status.placement with managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 			By("Checking the status.placement of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed2-status.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -87,33 +125,50 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placement-single-status.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("should contain status.placement with two pb/plr and both status", func() {
 			By("Creating pb-plr-2 to binding second set of placement")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr2", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr2", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placement-status.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("should still contain status.placement with two pb/plr and both status", func() {
 			By("Patch" + case2PolicyName + "-plr2 with both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr2", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr2", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placement-status.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -125,7 +180,10 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placement-status-missing-plr.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -137,7 +195,10 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placementbinding.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -152,7 +213,10 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Checking the status of root policy")
 			emptyStatus := map[string]interface{}{}
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(emptyStatus))
 		})
@@ -170,31 +234,46 @@ var _ = Describe("Test policy status aggregation", func() {
 			utils.Kubectl("apply",
 				"-f", case2PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should contain status.placement with violation status from both managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case2PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case2PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case2PolicyName,
+			}
 			By("Patching both replicated policy status to compliant")
 			replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 			for _, replicatedPlc := range replicatedPlcList.Items {
 				replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 					ComplianceState: policiesv1.Compliant,
 				}
-				_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+				_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+					context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+				)
 				Expect(err).To(BeNil())
 			}
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-status-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 			By("Patching both replicated policy status to noncompliant")
@@ -203,13 +282,18 @@ var _ = Describe("Test policy status aggregation", func() {
 				replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 					ComplianceState: policiesv1.NonCompliant,
 				}
-				_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+				_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+					context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+				)
 				Expect(err).To(BeNil())
 			}
 			By("Checking the status of root policy")
 			yamlPlc = utils.ParseYaml("../resources/case2_aggregation/managed-both-status-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})

--- a/test/e2e/case3_mutation_recovery_test.go
+++ b/test/e2e/case3_mutation_recovery_test.go
@@ -8,14 +8,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case3PolicyName string = "case3-test-policy"
-const case3PolicyYaml string = "../resources/case3_mutation_recovery/case3-test-policy.yaml"
+const (
+	case3PolicyName string = "case3-test-policy"
+	case3PolicyYaml string = "../resources/case3_mutation_recovery/case3-test-policy.yaml"
+)
 
 var _ = Describe("Test unexpected policy mutation", func() {
 	BeforeEach(func() {
@@ -23,12 +26,18 @@ var _ = Describe("Test unexpected policy mutation", func() {
 		utils.Kubectl("apply",
 			"-f", case3PolicyYaml,
 			"-n", testNamespace)
-		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds)
+		plc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds,
+		)
 		Expect(plc).NotTo(BeNil())
 		By("Patching test-policy-plr with decision of cluster managed1 and managed2")
-		plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case3PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+		plr := utils.GetWithTimeout(
+			clientHubDynamic, gvrPlacementRule, case3PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+		)
 		plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-		plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+		_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+			context.TODO(), plr, metav1.UpdateOptions{},
+		)
 		Expect(err).To(BeNil())
 		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case3PolicyName}
 		By("Patching both replicated policy status to compliant")
@@ -37,13 +46,18 @@ var _ = Describe("Test unexpected policy mutation", func() {
 			replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 				ComplianceState: policiesv1.Compliant,
 			}
-			_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+			_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+				context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 		}
 		By("Checking the status of root policy")
 		yamlPlc := utils.ParseYaml("../resources/case3_mutation_recovery/managed-both-status-compliant.yaml")
 		Eventually(func() interface{} {
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
 			return rootPlc.Object["status"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 	})
@@ -64,57 +78,87 @@ var _ = Describe("Test unexpected policy mutation", func() {
 	})
 	It("Should recover replicated policy when modified field disabled", func() {
 		By("Modifiying policy in cluster ns managed2")
-		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds)
+		plc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds,
+		)
 		Expect(plc).ToNot(BeNil())
 		plc.Object["spec"].(map[string]interface{})["disabled"] = true
-		plc, err := clientHubDynamic.Resource(gvrPolicy).Namespace("managed2").Update(context.TODO(), plc, metav1.UpdateOptions{})
+		plc, err := clientHubDynamic.Resource(gvrPolicy).Namespace("managed2").Update(
+			context.TODO(), plc, metav1.UpdateOptions{},
+		)
 		Expect(err).To(BeNil())
 		Expect(plc.Object["spec"].(map[string]interface{})["disabled"]).To(Equal(true))
 		By("Get policy in cluster ns managed2 again")
 		Eventually(func() interface{} {
-			plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
+
 			return plc.Object["spec"].(map[string]interface{})["disabled"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(false))
 	})
 	It("Should recover replicated policy when modified field remediationAction", func() {
 		By("Modifiying policy in cluster ns managed2")
-		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds)
+		plc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds,
+		)
 		Expect(plc).ToNot(BeNil())
 		plc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-		plc, err := clientHubDynamic.Resource(gvrPolicy).Namespace("managed2").Update(context.TODO(), plc, metav1.UpdateOptions{})
+		plc, err := clientHubDynamic.Resource(gvrPolicy).Namespace("managed2").Update(
+			context.TODO(), plc, metav1.UpdateOptions{},
+		)
 		Expect(err).To(BeNil())
 		Expect(plc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
 		By("Getting policy in cluster ns managed2 again")
 		Eventually(func() interface{} {
-			plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
+
 			return plc.Object["spec"].(map[string]interface{})["remediationAction"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual("inform"))
 	})
 	It("Should recover replicated policy when modified field policy-templates", func() {
 		By("Modifiying policy in cluster ns managed2")
-		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds)
+		plc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds,
+		)
 		Expect(plc).ToNot(BeNil())
 		plc.Object["spec"].(map[string]interface{})["policy-templates"] = []*policiesv1.PolicyTemplate{}
-		plc, err := clientHubDynamic.Resource(gvrPolicy).Namespace("managed2").Update(context.TODO(), plc, metav1.UpdateOptions{})
+		plc, err := clientHubDynamic.Resource(gvrPolicy).Namespace("managed2").Update(
+			context.TODO(), plc, metav1.UpdateOptions{},
+		)
 		Expect(err).To(BeNil())
 		By("Getting policy in cluster ns managed2 again")
-		rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds)
+		rootPlc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds,
+		)
 		Eventually(func() interface{} {
-			plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case3PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
+
 			return plc.Object["spec"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(rootPlc.Object["spec"]))
 	})
 	It("Should recover root policy status if modified", func() {
 		By("Modifiying policy in cluster ns managed2")
-		rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds)
+		rootPlc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds,
+		)
 		Expect(rootPlc).ToNot(BeNil())
 		rootPlc.Object["status"] = policiesv1.PolicyStatus{}
-		rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).UpdateStatus(context.TODO(), rootPlc, metav1.UpdateOptions{})
+		rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).UpdateStatus(
+			context.TODO(), rootPlc, metav1.UpdateOptions{},
+		)
 		Expect(err).To(BeNil())
 		By("Getting root policy again")
 		yamlPlc := utils.ParseYaml("../resources/case3_mutation_recovery/managed-both-status-compliant.yaml")
 		Eventually(func() interface{} {
-			rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
 			return rootPlc.Object["status"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 	})

--- a/test/e2e/case4_unexpected_policy_test.go
+++ b/test/e2e/case4_unexpected_policy_test.go
@@ -6,32 +6,46 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 )
 
-const case4PolicyName string = "case4-test-policy"
-const case4PolicyYaml string = "../resources/case4_unexpected_policy/case4-test-policy.yaml"
+const (
+	case4PolicyName string = "case4-test-policy"
+	case4PolicyYaml string = "../resources/case4_unexpected_policy/case4-test-policy.yaml"
+)
 
 var _ = Describe("Test unexpect policy handling", func() {
 	It("Unexpected root policy in cluster namespace should be deleted", func() {
 		By("Creating " + case4PolicyYaml + "in cluster namespace: managed1")
-		out, _ := utils.KubectlWithOutput("apply",
+		out, err := utils.KubectlWithOutput("apply",
 			"-f", case4PolicyYaml,
 			"-n", "managed1")
+		Expect(err).Should(BeNil())
 		Expect(out).Should(ContainSubstring(case4PolicyName + " created"))
 		Eventually(func() interface{} {
-			return utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case4PolicyName, "managed1", false, defaultTimeoutSeconds)
+			return utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case4PolicyName, "managed1", false, defaultTimeoutSeconds,
+			)
 		}, defaultTimeoutSeconds, 1).Should(BeNil())
 	})
 	It("Unexpected replicated policy in cluster namespace should be deleted", func() {
 		const plcYaml string = "../resources/case4_unexpected_policy/case4-test-replicated-policy.yaml"
 		By("Creating " + plcYaml + " in cluster namespace: managed1")
-		out, _ := utils.KubectlWithOutput("apply",
+		out, err := utils.KubectlWithOutput("apply",
 			"-f", plcYaml,
 			"-n", "managed1")
+		Expect(err).Should(BeNil())
 		Expect(out).Should(ContainSubstring("policy-propagator-test.case1-test-policy created"))
 		Eventually(func() interface{} {
-			return utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "policy-propagator-test.case1-test-policy", "managed1", false, defaultTimeoutSeconds)
+			return utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				"policy-propagator-test.case1-test-policy",
+				"managed1",
+				false,
+				defaultTimeoutSeconds,
+			)
 		}, defaultTimeoutSeconds, 1).Should(BeNil())
 	})
 })

--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -8,136 +8,212 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case5PolicyName string = "case5-test-policy"
-const case5PolicyYaml string = "../resources/case5_policy_automation/case5-test-policy.yaml"
+const (
+	case5PolicyName string = "case5-test-policy"
+	case5PolicyYaml string = "../resources/case5_policy_automation/case5-test-policy.yaml"
+)
 
 var _ = Describe("Test policy automation", func() {
 	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update pb/plc", func() {
 		It("should be created in user ns", func() {
 			By("Creating " + case5PolicyName)
-			utils.KubectlWithOutput("apply",
+			_, err := utils.KubectlWithOutput("apply",
 				"-f", case5PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case5PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			Expect(err).Should(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case5PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case5PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case5PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case5PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case5PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 	})
 	Describe("Test PolicyAutomation spec.mode", func() {
 		It("Test mode = disable", func() {
 			By("Creating an policyAutomation with mode=disable")
-			utils.KubectlWithOutput("apply",
+			_, err := utils.KubectlWithOutput("apply",
 				"-f", "../resources/case5_policy_automation/case5-policy-automation.yaml",
 				"-n", testNamespace)
+			Expect(err).Should(BeNil())
 			By("Should not create any ansiblejob when mode = disable")
 			Consistently(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(0))
 		})
 		It("Test mode = once", func() {
 			By("Patching policyAutomation with mode=once")
-			policyAutomation, err := clientHubDynamic.Resource(gvrPolicyAutomation).Namespace(testNamespace).Get(context.TODO(), "create-service-now-ticket", metav1.GetOptions{})
+			policyAutomation, err := clientHubDynamic.Resource(gvrPolicyAutomation).Namespace(testNamespace).Get(
+				context.TODO(), "create-service-now-ticket", metav1.GetOptions{},
+			)
 			Expect(err).To(BeNil())
 			policyAutomation.Object["spec"].(map[string]interface{})["mode"] = "once"
-			_, err = clientHubDynamic.Resource(gvrPolicyAutomation).Namespace(testNamespace).Update(context.TODO(), policyAutomation, metav1.UpdateOptions{})
+			_, err = clientHubDynamic.Resource(gvrPolicyAutomation).Namespace(testNamespace).Update(
+				context.TODO(), policyAutomation, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			By("Should still not create any ansiblejob when mode = once and policy is pending")
 			Consistently(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(0))
 			By("Should still not create any ansiblejob when mode = once and policy is Compliant")
 			Consistently(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(0))
 			By("Patching policy to make both cluster NonCompliant")
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case5PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case5PolicyName,
+			}
 			replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 			for _, replicatedPlc := range replicatedPlcList.Items {
 				replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 					ComplianceState: policiesv1.NonCompliant,
 				}
-				_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+				_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+					context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+				)
 				Expect(err).To(BeNil())
 			}
 			By("Should only create one ansiblejob when mode = once and policy is NonCompliant")
 			Eventually(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
-				utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				Expect(err).Should(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(1))
 			Consistently(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
-				utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				Expect(err).Should(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(1))
 			By("Mode should be set to disabled after ansiblejob is created")
-			policyAutomation, err = clientHubDynamic.Resource(gvrPolicyAutomation).Namespace(testNamespace).Get(context.TODO(), "create-service-now-ticket", metav1.GetOptions{})
+			policyAutomation, err = clientHubDynamic.Resource(gvrPolicyAutomation).Namespace(testNamespace).Get(
+				context.TODO(), "create-service-now-ticket", metav1.GetOptions{},
+			)
 			Expect(err).To(BeNil())
 			Expect(policyAutomation.Object["spec"].(map[string]interface{})["mode"]).To(Equal("disabled"))
 		})
 		It("Test manual run", func() {
 			By("Applying manual run annotation")
-			utils.KubectlWithOutput("annotate", "policyautomation", "-n", testNamespace, "create-service-now-ticket",
-				"--overwrite", "policy.open-cluster-management.io/rerun=true")
+			_, err := utils.KubectlWithOutput(
+				"annotate",
+				"policyautomation",
+				"-n",
+				testNamespace,
+				"create-service-now-ticket",
+				"--overwrite",
+				"policy.open-cluster-management.io/rerun=true",
+			)
+			Expect(err).Should(BeNil())
 			By("Should only create one more ansiblejob because policy is NonCompliant")
 			Eventually(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
-				utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				Expect(err).Should(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(2))
 			Consistently(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
-				utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				Expect(err).Should(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(2))
 			By("Patching policy to make both cluster Compliant")
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case5PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case5PolicyName,
+			}
 			replicatedPlcList := utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 			for _, replicatedPlc := range replicatedPlcList.Items {
 				replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 					ComplianceState: policiesv1.Compliant,
 				}
-				_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+				_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+					context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+				)
 				Expect(err).To(BeNil())
 			}
 			By("Applying manual run annotation again")
-			utils.KubectlWithOutput("annotate", "policyautomation", "-n", testNamespace, "create-service-now-ticket",
-				"--overwrite", "policy.open-cluster-management.io/rerun=true")
+			_, err = utils.KubectlWithOutput(
+				"annotate",
+				"policyautomation",
+				"-n",
+				testNamespace,
+				"create-service-now-ticket",
+				"--overwrite",
+				"policy.open-cluster-management.io/rerun=true",
+			)
+			Expect(err).Should(BeNil())
 			By("Should still create one more ansiblejob when policy is Compliant")
 			Eventually(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
-				utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				Expect(err).Should(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(3))
 			Consistently(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
-				utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				Expect(err).Should(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(3))
 		})
@@ -145,15 +221,22 @@ var _ = Describe("Test policy automation", func() {
 	Describe("Clean up", func() {
 		It("Test AnsibleJob clean up", func() {
 			By("Removing config map")
-			utils.KubectlWithOutput("delete", "policyautomation", "-n", testNamespace, "create-service-now-ticket")
+			_, err := utils.KubectlWithOutput(
+				"delete", "policyautomation", "-n", testNamespace, "create-service-now-ticket",
+			)
+			Expect(err).Should(BeNil())
 			By("Ansiblejob should also be removed")
 			Eventually(func() interface{} {
-				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				ansiblejobList, err := clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
+					context.TODO(), metav1.ListOptions{},
+				)
 				Expect(err).To(BeNil())
+
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(0))
 			By("Removing policy")
-			utils.KubectlWithOutput("delete", "policy", "-n", testNamespace, case5PolicyName)
+			_, err = utils.KubectlWithOutput("delete", "policy", "-n", testNamespace, case5PolicyName)
+			Expect(err).Should(BeNil())
 		})
 	})
 })

--- a/test/e2e/case6_placement_propagation_test.go
+++ b/test/e2e/case6_placement_propagation_test.go
@@ -8,14 +8,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case6PolicyName string = "case6-test-policy"
-const case6PolicyYaml string = "../resources/case6_placement_propagation/case6-test-policy.yaml"
+const (
+	case6PolicyName string = "case6-test-policy"
+	case6PolicyYaml string = "../resources/case6_placement_propagation/case6-test-policy.yaml"
+)
 
 var _ = Describe("Test policy propagation", func() {
 	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update pb/plc", func() {
@@ -24,93 +27,191 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case6PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(),
-				plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(),
+				plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1", "managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(),
-				plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed2", false, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				testNamespace+"."+case6PolicyName,
+				"managed2",
+				false,
+				defaultTimeoutSeconds,
+			)
 			Expect(plc).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1", "managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a non existing plr")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["placementRef"] = &policiesv1.Subject{
 				APIGroup: "cluster.open-cluster-management.io",
 				Kind:     "Placement",
 				Name:     case6PolicyName + "-plr-nonexists",
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plr")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["placementRef"] = &policiesv1.Subject{
 				APIGroup: "cluster.open-cluster-management.io",
 				Kind:     "Placement",
 				Name:     case6PolicyName + "-plr",
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a plc with wrong apigroup")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy1.open-cluster-management.io",
@@ -118,14 +219,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case6PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -133,14 +245,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case6PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a plc with wrong kind")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -148,14 +271,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case6PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -163,14 +297,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case6PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with a plc with wrong name")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -178,14 +323,25 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case6PolicyName + "1",
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case6PolicyName+"-pb", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case6PolicyName+"-pb",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["subjects"] = []policiesv1.Subject{
 				{
 					APIGroup: "policy.open-cluster-management.io",
@@ -193,19 +349,32 @@ var _ = Describe("Test policy propagation", func() {
 					Name:     case6PolicyName,
 				},
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting decision for test-policy-plr")
-			utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			// remove the placementdecision will remove the policy from all managed clusters
 			utils.Kubectl("delete",
 				"placementdecision", case6PolicyName+"-plr-1",
 				"-n", testNamespace)
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should clean up", func() {
@@ -223,43 +392,76 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case6PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should update replicated policy in ns managed1", func() {
 			By("Patching test-policy with spec.remediationAction = enforce")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(rootPlc).NotTo(BeNil())
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("inform"))
 			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(
+				context.TODO(), rootPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			Eventually(func() interface{} {
-				replicatedPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds)
+				replicatedPlc := utils.GetWithTimeout(
+					clientHubDynamic,
+					gvrPolicy,
+					testNamespace+"."+case6PolicyName,
+					"managed1",
+					true,
+					defaultTimeoutSeconds,
+				)
+
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(rootPlc.Object["spec"]))
 		})
 		It("should remove replicated policy in ns managed1", func() {
 			By("Patching test-policy with spec.disabled = true")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(rootPlc).NotTo(BeNil())
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["disabled"]).To(Equal(false))
 			rootPlc.Object["spec"].(map[string]interface{})["disabled"] = true
-			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			rootPlc, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Update(
+				context.TODO(), rootPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["disabled"]).To(Equal(true))
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
 		It("should be created in user ns", func() {
@@ -267,18 +469,38 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case6PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case6PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case6PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				testNamespace+"."+case6PolicyName,
+				"managed1",
+				true,
+				defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("should update test-policy to a different policy template", func() {
@@ -286,11 +508,21 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", "../resources/case6_placement_propagation/case6-test-policy2.yaml",
 				"-n", testNamespace)
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case6PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(rootPlc).NotTo(BeNil())
 			yamlPlc := utils.ParseYaml("../resources/case6_placement_propagation/case6-test-policy2.yaml")
 			Eventually(func() interface{} {
-				replicatedPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName, "managed1", true, defaultTimeoutSeconds)
+				replicatedPlc := utils.GetWithTimeout(
+					clientHubDynamic,
+					gvrPolicy,
+					testNamespace+"."+case6PolicyName,
+					"managed1",
+					true,
+					defaultTimeoutSeconds,
+				)
+
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
 		})

--- a/test/e2e/case7_bindings_test.go
+++ b/test/e2e/case7_bindings_test.go
@@ -8,18 +8,21 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case7PolicyName string = "case7-test-policy"
-const case7PolicyYaml string = "../resources/case7_placement_bindings/case7-test-policy.yaml"
-const case7BindingYaml1 string = "../resources/case7_placement_bindings/case7-test-binding1.yaml"
-const case7BindingYaml2 string = "../resources/case7_placement_bindings/case7-test-binding2.yaml"
-const case7BindingYaml3 string = "../resources/case7_placement_bindings/case7-test-binding3.yaml"
-const case7BindingYaml4 string = "../resources/case7_placement_bindings/case7-test-binding4.yaml"
+const (
+	case7PolicyName   string = "case7-test-policy"
+	case7PolicyYaml   string = "../resources/case7_placement_bindings/case7-test-policy.yaml"
+	case7BindingYaml1 string = "../resources/case7_placement_bindings/case7-test-binding1.yaml"
+	case7BindingYaml2 string = "../resources/case7_placement_bindings/case7-test-binding2.yaml"
+	case7BindingYaml3 string = "../resources/case7_placement_bindings/case7-test-binding3.yaml"
+	case7BindingYaml4 string = "../resources/case7_placement_bindings/case7-test-binding4.yaml"
+)
 
 var _ = Describe("Test policy propagation", func() {
 	Describe("Create policy/pb/plc in ns:"+testNamespace, func() {
@@ -28,98 +31,187 @@ var _ = Describe("Test policy propagation", func() {
 			utils.Kubectl("apply",
 				"-f", case7PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case7PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case7PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 			By("Creating " + case7BindingYaml1)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml1,
 				"-n", testNamespace)
-			binding := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, "case7-test-policy-pb1", testNamespace, true, defaultTimeoutSeconds)
+			binding := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				"case7-test-policy-pb1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			Expect(binding).NotTo(BeNil())
 			By("Creating " + case7BindingYaml2)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml2,
 				"-n", testNamespace)
-			binding = utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, "case7-test-policy-pb2", testNamespace, true, defaultTimeoutSeconds)
+			binding = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				"case7-test-policy-pb2",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			Expect(binding).NotTo(BeNil())
 			By("Creating " + case7BindingYaml3)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml3,
 				"-n", testNamespace)
-			binding = utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, "case7-test-policy-pb3", testNamespace, true, defaultTimeoutSeconds)
+			binding = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				"case7-test-policy-pb3",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			Expect(binding).NotTo(BeNil())
 			By("Creating " + case7BindingYaml4)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml4,
 				"-n", testNamespace)
-			binding = utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, "case7-test-policy-pb4", testNamespace, true, defaultTimeoutSeconds)
+			binding = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				"case7-test-policy-pb4",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			Expect(binding).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case7PolicyName+"-plr-1", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case7PolicyName+"-plr-1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(),
-				plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case7PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case7PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("placement bindings propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementDecision, case7PolicyName+"-plr-2", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementDecision,
+				case7PolicyName+"-plr-2",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePldStatus(plr.GetName(), plr.GetNamespace(), "managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case7PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case7PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed2", func() {
 			By("Patching test-policy-pb with a non existing plr")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case7PolicyName+"-pb2", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case7PolicyName+"-pb2",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["placementRef"] = &policiesv1.Subject{
 				APIGroup: "cluster.open-cluster-management.io",
 				Kind:     "Placement",
 				Name:     case7PolicyName + "-plr-nonexists",
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("mixed placement propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case7PolicyName+"-plr3", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case7PolicyName+"-plr3", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should remove policy from ns managed2", func() {
 			By("Patching test-policy-pb with a non existing plr")
-			pb := utils.GetWithTimeout(clientHubDynamic, gvrPlacementBinding, case7PolicyName+"-pb1", testNamespace, true, defaultTimeoutSeconds)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPlacementBinding,
+				case7PolicyName+"-pb1",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
 			pb.Object["placementRef"] = &policiesv1.Subject{
 				APIGroup: "cluster.open-cluster-management.io",
 				Kind:     "Placement",
 				Name:     case7PolicyName + "-plr-nonexists",
 			}
-			pb, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(context.TODO(), pb, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), pb, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 		})
 		It("app placement propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-plr with decision of both managed1 and managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case7PolicyName+"-plr4", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case7PolicyName+"-plr4", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName}
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case7PolicyName,
+			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
 		It("should clean up policy", func() {

--- a/test/e2e/case8_metrics_test.go
+++ b/test/e2e/case8_metrics_test.go
@@ -7,14 +7,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/controllers/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const case8PolicyName string = "case8-test-policy"
-const case8PolicyYaml string = "../resources/case8_metrics/case8-test-policy.yaml"
+const (
+	case8PolicyName string = "case8-test-policy"
+	case8PolicyYaml string = "../resources/case8_metrics/case8-test-policy.yaml"
+)
 
 var _ = Describe("Test metrics appear locally", func() {
 	It("should report 0 for compliant root policy and replicated policies", func() {
@@ -22,14 +25,22 @@ var _ = Describe("Test metrics appear locally", func() {
 		utils.Kubectl("apply",
 			"-f", case8PolicyYaml,
 			"-n", testNamespace)
-		plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds)
+		plc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds,
+		)
 		Expect(plc).NotTo(BeNil())
 		By("Patching test-policy-plr with decision of cluster managed1 and managed2")
-		plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case8PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+		plr := utils.GetWithTimeout(
+			clientHubDynamic, gvrPlacementRule, case8PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+		)
 		plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
-		_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+		_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+			context.TODO(), plr, metav1.UpdateOptions{},
+		)
 		Expect(err).To(BeNil())
-		plc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case8PolicyName, "managed2", true, defaultTimeoutSeconds)
+		plc = utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, testNamespace+"."+case8PolicyName, "managed2", true, defaultTimeoutSeconds,
+		)
 		Expect(plc).ToNot(BeNil())
 		opt := metav1.ListOptions{LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case8PolicyName}
 		By("Patching both replicated policy status to compliant")
@@ -38,13 +49,18 @@ var _ = Describe("Test metrics appear locally", func() {
 			replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 				ComplianceState: policiesv1.Compliant,
 			}
-			_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+			_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+				context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 		}
 		By("Checking the status of root policy")
 		yamlPlc := utils.ParseYaml("../resources/case8_metrics/managed-both-status-compliant.yaml")
 		Eventually(func() interface{} {
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
 			return rootPlc.Object["status"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		By("Checking metric endpoint for root policy status")
@@ -53,11 +69,15 @@ var _ = Describe("Test metrics appear locally", func() {
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics(
+				"policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`,
+			)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics(
+				"policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`,
+			)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"0"}))
 	})
 	It("should report 1 for noncompliant root policy and replicated policies", func() {
@@ -68,13 +88,18 @@ var _ = Describe("Test metrics appear locally", func() {
 			replicatedPlc.Object["status"] = &policiesv1.PolicyStatus{
 				ComplianceState: policiesv1.NonCompliant,
 			}
-			_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(context.TODO(), &replicatedPlc, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPolicy).Namespace(replicatedPlc.GetNamespace()).UpdateStatus(
+				context.TODO(), &replicatedPlc, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
 		}
 		By("Checking the status of root policy")
 		yamlPlc := utils.ParseYaml("../resources/case8_metrics/managed-both-status-noncompliant.yaml")
 		Eventually(func() interface{} {
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
 			return rootPlc.Object["status"]
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		By("Checking metric endpoint for root policy status")
@@ -83,11 +108,15 @@ var _ = Describe("Test metrics appear locally", func() {
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics(
+				"policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`,
+			)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics(
+				"policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`,
+			)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"1"}))
 	})
 	It("should not report metrics for policies after they are deleted", func() {
@@ -103,11 +132,15 @@ var _ = Describe("Test metrics appear locally", func() {
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 		By("Checking metric endpoint for managed1 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`)
+			return utils.GetMetrics(
+				"policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed1\",`,
+			)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 		By("Checking metric endpoint for managed2 replicated policy status")
 		Eventually(func() interface{} {
-			return utils.GetMetrics("policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`)
+			return utils.GetMetrics(
+				"policy_governance_info", `policy=\"case8-test-policy\"`, `cluster_namespace=\"managed2\",`,
+			)
 		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
 	})
 })

--- a/test/e2e/case9_templates_test.go
+++ b/test/e2e/case9_templates_test.go
@@ -8,14 +8,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 )
 
-const case9PolicyName string = "case9-test-policy"
-const case9PolicyYaml string = "../resources/case9_templates/case9-test-policy.yaml"
-const case9ReplicatedPolicyYamlM1 string = "../resources/case9_templates/case9-test-replpolicy-managed1.yaml"
-const case9ReplicatedPolicyYamlM2 string = "../resources/case9_templates/case9-test-replpolicy-managed2.yaml"
+const (
+	case9PolicyName             string = "case9-test-policy"
+	case9PolicyYaml             string = "../resources/case9_templates/case9-test-policy.yaml"
+	case9ReplicatedPolicyYamlM1 string = "../resources/case9_templates/case9-test-replpolicy-managed1.yaml"
+	case9ReplicatedPolicyYamlM2 string = "../resources/case9_templates/case9-test-replpolicy-managed2.yaml"
+)
 
 var _ = Describe("Test policy templates", func() {
 	Describe("Create policy, placement and referenced resource in ns:"+testNamespace, func() {
@@ -24,36 +27,66 @@ var _ = Describe("Test policy templates", func() {
 			utils.Kubectl("apply",
 				"-f", case9PolicyYaml,
 				"-n", testNamespace)
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, case9PolicyName, testNamespace, true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, case9PolicyName, testNamespace, true, defaultTimeoutSeconds,
+			)
 			Expect(plc).NotTo(BeNil())
 		})
 		It("should resolve templates and propagate to cluster ns managed1", func() {
 			By("Patching test-policy-plr with decision of cluster managed1")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case9PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case9PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case9PolicyName, "managed1", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case9PolicyName, "managed1", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
 
 			yamlPlc := utils.ParseYaml(case9ReplicatedPolicyYamlM1)
 			Eventually(func() interface{} {
-				replicatedPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case9PolicyName, "managed1", true, defaultTimeoutSeconds)
+				replicatedPlc := utils.GetWithTimeout(
+					clientHubDynamic,
+					gvrPolicy,
+					testNamespace+"."+case9PolicyName,
+					"managed1",
+					true,
+					defaultTimeoutSeconds,
+				)
+
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
 		})
 		It("should resolve templates and propagate to cluster ns managed2", func() {
 			By("Patching test-policy-plr with decision of cluster managed2")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, case9PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case9PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+			)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
-			plr, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
 			Expect(err).To(BeNil())
-			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case9PolicyName, "managed2", true, defaultTimeoutSeconds)
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case9PolicyName, "managed2", true, defaultTimeoutSeconds,
+			)
 			Expect(plc).ToNot(BeNil())
 
 			yamlPlc := utils.ParseYaml(case9ReplicatedPolicyYamlM2)
 			Eventually(func() interface{} {
-				replicatedPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case9PolicyName, "managed2", true, defaultTimeoutSeconds)
+				replicatedPlc := utils.GetWithTimeout(
+					clientHubDynamic,
+					gvrPolicy,
+					testNamespace+"."+case9PolicyName,
+					"managed2",
+					true,
+					defaultTimeoutSeconds,
+				)
+
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
 		})
@@ -64,6 +97,5 @@ var _ = Describe("Test policy templates", func() {
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, defaultTimeoutSeconds)
 		})
-
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -35,14 +35,8 @@ var (
 	gvrPlacement          schema.GroupVersionResource
 	gvrPlacementDecision  schema.GroupVersionResource
 	gvrAnsibleJob         schema.GroupVersionResource
-	optionsFile           string
-	baseDomain            string
-	kubeadminUser         string
-	kubeadminCredential   string
-	kubeconfig            string
 	defaultTimeoutSeconds int
-
-	defaultImageRegistry string
+	defaultImageRegistry  string
 )
 
 func TestE2e(t *testing.T) {
@@ -53,26 +47,31 @@ func TestE2e(t *testing.T) {
 func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
-
-	// flag.StringVar(&kubeadminUser, "kubeadmin-user", "kubeadmin", "Provide the kubeadmin credential for the cluster under test (e.g. -kubeadmin-user=\"xxxxx\").")
-	// flag.StringVar(&kubeadminCredential, "kubeadmin-credential", "",
-	// 	"Provide the kubeadmin credential for the cluster under test (e.g. -kubeadmin-credential=\"xxxxx-xxxxx-xxxxx-xxxxx\").")
-	// flag.StringVar(&baseDomain, "base-domain", "", "Provide the base domain for the cluster under test (e.g. -base-domain=\"demo.red-chesterfield.com\").")
-	// flag.StringVar(&kubeconfig, "kubeconfig", "", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
-
-	// flag.StringVar(&optionsFile, "options", "", "Location of an \"options.yaml\" file to provide input for various tests")
-
 }
 
 var _ = BeforeSuite(func() {
 	By("Setup Hub client")
-	gvrPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
-	gvrPlacementBinding = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings"}
-	gvrPlacementRule = schema.GroupVersionResource{Group: "apps.open-cluster-management.io", Version: "v1", Resource: "placementrules"}
-	gvrPlacement = schema.GroupVersionResource{Group: "cluster.open-cluster-management.io", Version: "v1alpha1", Resource: "placements"}
-	gvrPlacementDecision = schema.GroupVersionResource{Group: "cluster.open-cluster-management.io", Version: "v1alpha1", Resource: "placementdecisions"}
-	gvrPolicyAutomation = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1beta1", Resource: "policyautomations"}
-	gvrAnsibleJob = schema.GroupVersionResource{Group: "tower.ansible.com", Version: "v1alpha1", Resource: "ansiblejobs"}
+	gvrPolicy = schema.GroupVersionResource{
+		Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies",
+	}
+	gvrPlacementBinding = schema.GroupVersionResource{
+		Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings",
+	}
+	gvrPlacementRule = schema.GroupVersionResource{
+		Group: "apps.open-cluster-management.io", Version: "v1", Resource: "placementrules",
+	}
+	gvrPlacement = schema.GroupVersionResource{
+		Group: "cluster.open-cluster-management.io", Version: "v1alpha1", Resource: "placements",
+	}
+	gvrPlacementDecision = schema.GroupVersionResource{
+		Group: "cluster.open-cluster-management.io", Version: "v1alpha1", Resource: "placementdecisions",
+	}
+	gvrPolicyAutomation = schema.GroupVersionResource{
+		Group: "policy.open-cluster-management.io", Version: "v1beta1", Resource: "policyautomations",
+	}
+	gvrAnsibleJob = schema.GroupVersionResource{
+		Group: "tower.ansible.com", Version: "v1alpha1", Resource: "ansiblejobs",
+	}
 	clientHub = NewKubeClient("", "", "")
 	clientHubDynamic = NewKubeClientDynamic("", "", "")
 	defaultImageRegistry = "quay.io/open-cluster-management"
@@ -80,7 +79,9 @@ var _ = BeforeSuite(func() {
 	defaultTimeoutSeconds = 30
 	By("Create Namesapce if needed")
 	namespaces := clientHub.CoreV1().Namespaces()
-	if _, err := namespaces.Get(context.TODO(), testNamespace, metav1.GetOptions{}); err != nil && errors.IsNotFound(err) {
+	if _, err := namespaces.Get(
+		context.TODO(), testNamespace, metav1.GetOptions{},
+	); err != nil && errors.IsNotFound(err) {
 		Expect(namespaces.Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testNamespace,
@@ -92,6 +93,7 @@ var _ = BeforeSuite(func() {
 
 func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {
 	klog.V(5).Infof("Create kubeclient for url %s using kubeconfig path %s\n", url, kubeconfig)
+
 	config, err := LoadConfig(url, kubeconfig, context)
 	if err != nil {
 		panic(err)
@@ -107,6 +109,7 @@ func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {
 
 func NewKubeClientDynamic(url, kubeconfig, context string) dynamic.Interface {
 	klog.V(5).Infof("Create kubeclient dynamic for url %s using kubeconfig path %s\n", url, kubeconfig)
+
 	config, err := LoadConfig(url, kubeconfig, context)
 	if err != nil {
 		panic(err)
@@ -124,30 +127,39 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 	if kubeconfig == "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
 	}
+
 	klog.V(5).Infof("Kubeconfig path %s\n", kubeconfig)
+
 	// If we have an explicit indication of where the kubernetes config lives, read that.
 	if kubeconfig != "" {
 		if context == "" {
 			return clientcmd.BuildConfigFromFlags(url, kubeconfig)
 		}
+
 		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
 			&clientcmd.ConfigOverrides{
 				CurrentContext: context,
 			}).ClientConfig()
 	}
+
 	// If not, try the in-cluster config.
 	if c, err := rest.InClusterConfig(); err == nil {
 		return c, nil
 	}
+
 	// If no in-cluster config, try the default location in the user's home directory.
 	if usr, err := user.Current(); err == nil {
-		klog.V(5).Infof("clientcmd.BuildConfigFromFlags for url %s using %s\n", url, filepath.Join(usr.HomeDir, ".kube", "config"))
+		klog.V(5).Infof(
+			"clientcmd.BuildConfigFromFlags for url %s using %s\n",
+			url,
+			filepath.Join(usr.HomeDir, ".kube", "config"),
+		)
+
 		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
 			return c, nil
 		}
 	}
 
 	return nil, fmt.Errorf("could not create a valid kubeconfig")
-
 }

--- a/test/utils/semanticMatcher.go
+++ b/test/utils/semanticMatcher.go
@@ -4,10 +4,10 @@
 package utils
 
 import (
+	"fmt"
+
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/api/equality"
-
-	"fmt"
 )
 
 func SemanticEqual(expected interface{}) types.GomegaMatcher {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -32,11 +32,14 @@ func GeneratePlrStatus(clusters ...string) *appsv1.PlacementRuleStatus {
 			ClusterNamespace: cluster,
 		})
 	}
+
 	return &appsv1.PlacementRuleStatus{Decisions: plrDecision}
 }
 
 // GeneratePldStatus generate pld status with given clusters
-func GeneratePldStatus(placementName string, placementNamespace string, clusters ...string) *clusterv1alpha1.PlacementDecisionStatus {
+func GeneratePldStatus(
+	placementName string, placementNamespace string, clusters ...string,
+) *clusterv1alpha1.PlacementDecisionStatus {
 	plrDecision := []clusterv1alpha1.ClusterDecision{}
 	for _, cluster := range clusters {
 		plrDecision = append(plrDecision, clusterv1alpha1.ClusterDecision{
@@ -44,6 +47,7 @@ func GeneratePldStatus(placementName string, placementNamespace string, clusters
 			Reason:      "test",
 		})
 	}
+
 	return &clusterv1alpha1.PlacementDecisionStatus{Decisions: plrDecision}
 }
 
@@ -52,6 +56,7 @@ func Pause(s uint) {
 	if s < 1 {
 		s = 1
 	}
+
 	time.Sleep(time.Duration(float64(s)) * time.Second)
 }
 
@@ -59,13 +64,16 @@ func Pause(s uint) {
 func ParseYaml(file string) *unstructured.Unstructured {
 	yamlFile, err := ioutil.ReadFile(file)
 	Expect(err).To(BeNil())
+
 	yamlPlc := &unstructured.Unstructured{}
 	err = yaml.Unmarshal(yamlFile, yamlPlc)
 	Expect(err).To(BeNil())
+
 	return yamlPlc
 }
 
-// GetClusterLevelWithTimeout keeps polling to get the object for timeout seconds until wantFound is met (true for found, false for not found)
+// GetClusterLevelWithTimeout keeps polling to get the object for timeout seconds until wantFound is met
+// (true for found, false for not found)
 func GetClusterLevelWithTimeout(
 	clientHubDynamic dynamic.Interface,
 	gvr schema.GroupVersionResource,
@@ -76,30 +84,38 @@ func GetClusterLevelWithTimeout(
 	if timeout < 1 {
 		timeout = 1
 	}
+
 	var obj *unstructured.Unstructured
 
 	Eventually(func() error {
 		var err error
 		namespace := clientHubDynamic.Resource(gvr)
+
 		obj, err = namespace.Get(context.TODO(), name, metav1.GetOptions{})
 		if wantFound && err != nil {
 			return err
 		}
+
 		if !wantFound && err == nil {
 			return fmt.Errorf("expected to return IsNotFound error")
 		}
+
 		if !wantFound && err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+
 		return nil
 	}, timeout, 1).Should(BeNil())
+
 	if wantFound {
 		return obj
 	}
+
 	return nil
 }
 
-// GetWithTimeout keeps polling to get the object for timeout seconds until wantFound is met (true for found, false for not found)
+// GetWithTimeout keeps polling to get the object for timeout seconds until wantFound is met
+// (true for found, false for not found)
 func GetWithTimeout(
 	clientHubDynamic dynamic.Interface,
 	gvr schema.GroupVersionResource,
@@ -110,31 +126,38 @@ func GetWithTimeout(
 	if timeout < 1 {
 		timeout = 1
 	}
+
 	var obj *unstructured.Unstructured
 
 	Eventually(func() error {
 		var err error
 		namespace := clientHubDynamic.Resource(gvr).Namespace(namespace)
+
 		obj, err = namespace.Get(context.TODO(), name, metav1.GetOptions{})
 		if wantFound && err != nil {
 			return err
 		}
+
 		if !wantFound && err == nil {
 			return fmt.Errorf("expected to return IsNotFound error")
 		}
+
 		if !wantFound && err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+
 		return nil
 	}, timeout, 1).Should(BeNil())
+
 	if wantFound {
 		return obj
 	}
-	return nil
 
+	return nil
 }
 
-// ListWithTimeout keeps polling to list the object for timeout seconds until wantFound is met (true for found, false for not found)
+// ListWithTimeout keeps polling to list the object for timeout seconds until wantFound is met
+// (true for found, false for not found)
 func ListWithTimeout(
 	clientHubDynamic dynamic.Interface,
 	gvr schema.GroupVersionResource,
@@ -146,29 +169,33 @@ func ListWithTimeout(
 	if timeout < 1 {
 		timeout = 1
 	}
+
 	var list *unstructured.UnstructuredList
 
 	Eventually(func() error {
 		var err error
 		list, err = clientHubDynamic.Resource(gvr).List(context.TODO(), opts)
+
 		if err != nil {
 			return err
-		} else {
-			if len(list.Items) != size {
-				return fmt.Errorf("list size doesn't match, expected %d actual %d", size, len(list.Items))
-			} else {
-				return nil
-			}
 		}
+
+		if len(list.Items) != size {
+			return fmt.Errorf("list size doesn't match, expected %d actual %d", size, len(list.Items))
+		}
+
+		return nil
 	}, timeout, 1).Should(BeNil())
+
 	if wantFound {
 		return list
 	}
-	return nil
 
+	return nil
 }
 
-// ListWithTimeoutByNamespace keeps polling to list the object for timeout seconds until wantFound is met (true for found, false for not found)
+// ListWithTimeoutByNamespace keeps polling to list the object for timeout seconds until wantFound is met
+// (true for found, false for not found)
 func ListWithTimeoutByNamespace(
 	clientHubDynamic dynamic.Interface,
 	gvr schema.GroupVersionResource,
@@ -181,31 +208,35 @@ func ListWithTimeoutByNamespace(
 	if timeout < 1 {
 		timeout = 1
 	}
+
 	var list *unstructured.UnstructuredList
 
 	Eventually(func() error {
 		var err error
 		list, err = clientHubDynamic.Resource(gvr).Namespace(ns).List(context.TODO(), opts)
+
 		if err != nil {
 			return err
-		} else {
-			if len(list.Items) != size {
-				return fmt.Errorf("list size doesn't match, expected %d actual %d", size, len(list.Items))
-			} else {
-				return nil
-			}
 		}
+
+		if len(list.Items) != size {
+			return fmt.Errorf("list size doesn't match, expected %d actual %d", size, len(list.Items))
+		}
+
+		return nil
 	}, timeout, 1).Should(BeNil())
+
 	if wantFound {
 		return list
 	}
-	return nil
 
+	return nil
 }
 
 // Kubectl execute kubectl cli
 func Kubectl(args ...string) {
 	cmd := exec.Command("kubectl", args...)
+
 	err := cmd.Start()
 	if err != nil {
 		Fail(fmt.Sprintf("Error: %v", err))
@@ -215,7 +246,9 @@ func Kubectl(args ...string) {
 // KubectlWithOutput execute kubectl cli and return output and error
 func KubectlWithOutput(args ...string) (string, error) {
 	output, err := exec.Command("kubectl", args...).CombinedOutput()
+	// nolint: forbidigo
 	fmt.Println(string(output))
+
 	return string(output), err
 }
 
@@ -228,21 +261,25 @@ func GetMetrics(metricPatterns ...string) []string {
 	if err != nil {
 		return []string{err.Error()}
 	}
+
 	propPodName := strings.Split(propPodInfo, " ")[0]
 
 	metricFilter := " | grep " + strings.Join(metricPatterns, " | grep ")
 	cmd := exec.Command("kubectl", "exec", "-n=open-cluster-management", propPodName, "-c",
 		"governance-policy-propagator", "--", "bash", "-c", `curl localhost:8383/metrics`+metricFilter)
+
 	matchingMetricsRaw, err := cmd.Output()
 	if err != nil {
 		if err.Error() == "exit status 1" {
 			return []string{} // exit 1 indicates that grep couldn't find a match.
 		}
+
 		return []string{err.Error()}
 	}
 
 	matchingMetrics := strings.Split(strings.TrimSpace(string(matchingMetricsRaw)), "\n")
 	values := make([]string, len(matchingMetrics))
+
 	for i, metric := range matchingMetrics {
 		fields := strings.Fields(metric)
 		if len(fields) > 0 {

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,4 @@
 
 package version
 
-var (
-	Version = "0.0.1"
-)
+var Version = "0.0.1"


### PR DESCRIPTION
As a team, we decided which linting rules we want to enforce:
https://github.com/open-cluster-management/backlog/issues/17089

Based on that discussion, the linters were configured and reenabled.
This commit also fixes all the linting errors.

One caveat is that `forcetypeassert` linting errors were disabled on the
offending lines since the calling code is from the controller runtime
which is validated from the Kubernetes API, so the type will always be
as expected.

Resolves:
https://github.com/open-cluster-management/governance-policy-propagator/pull/117