### PR TITLE
Restrict length of pb.spec.subjects to 1 

### DIFF
--- a/api/v1/placementbinding_types.go
+++ b/api/v1/placementbinding_types.go
@@ -14,6 +14,21 @@ type Subject struct {
 	APIGroup string `json:"apiGroup"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Enum=Policy
+	Kind string `json:"kind"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	Name string `json:"name"`
+}
+
+// PlacementSubject reference
+type PlacementSubject struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	APIGroup string `json:"apiGroup"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Enum=PlacementRule;Placement
 	Kind string `json:"kind"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
@@ -33,8 +48,10 @@ type PlacementBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:Required
-	PlacementRef Subject `json:"placementRef"`
+	PlacementRef PlacementSubject `json:"placementRef"`
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxItems=1
+	// +kubebuilder:validation:MinItems=1
 	Subjects []Subject              `json:"subjects"`
 	Status   PlacementBindingStatus `json:"status,omitempty"`
 }

--- a/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
@@ -36,12 +36,15 @@ spec:
           metadata:
             type: object
           placementRef:
-            description: Subject reference
+            description: PlacementSubject reference
             properties:
               apiGroup:
                 minLength: 1
                 type: string
               kind:
+                enum:
+                - PlacementRule
+                - Placement
                 minLength: 1
                 type: string
               name:
@@ -63,6 +66,8 @@ spec:
                   minLength: 1
                   type: string
                 kind:
+                  enum:
+                  - Policy
                   minLength: 1
                   type: string
                 name:
@@ -73,6 +78,8 @@ spec:
               - kind
               - name
               type: object
+            maxItems: 1
+            minItems: 1
             type: array
         required:
         - placementRef

--- a/test/e2e/case1_propagation_test.go
+++ b/test/e2e/case1_propagation_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Test policy propagation", func() {
 			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
-		It("should remove policy from ns managed1 and managed2", func() {
+		It("should prevent user from creating subject with unsupported kind", func() {
 			By("Patching test-policy-pb with a plc with wrong kind")
 			pb := utils.GetWithTimeout(
 				clientHubDynamic,
@@ -252,11 +252,7 @@ var _ = Describe("Test policy propagation", func() {
 			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
 				context.TODO(), pb, metav1.UpdateOptions{},
 			)
-			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{
-				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case1PolicyName,
-			}
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+			Expect(err).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")

--- a/test/e2e/case6_placement_propagation_test.go
+++ b/test/e2e/case6_placement_propagation_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Test policy propagation", func() {
 			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
 		})
-		It("should remove policy from ns managed1 and managed2", func() {
+		It("should prevent user from creating subject with unsupported kind", func() {
 			By("Patching test-policy-pb with a plc with wrong kind")
 			pb := utils.GetWithTimeout(
 				clientHubDynamic,
@@ -274,11 +274,7 @@ var _ = Describe("Test policy propagation", func() {
 			_, err := clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
 				context.TODO(), pb, metav1.UpdateOptions{},
 			)
-			Expect(err).To(BeNil())
-			opt := metav1.ListOptions{
-				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case6PolicyName,
-			}
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+			Expect(err).NotTo(BeNil())
 		})
 		It("should propagate to cluster ns managed1 and managed2", func() {
 			By("Patching test-policy-pb with correct plc")


### PR DESCRIPTION
The propagator only handles first matching subject in placementbinding.
See https://tinyurl.com/yrtd6e4r. Add this restriction to CRD.

Signed-off-by: Yu Cao <ycao@redhat.com>